### PR TITLE
feat: add bash tool-calling flow for cerebras and ollama

### DIFF
--- a/src/bashGPT/Cli/PromptHandler.cs
+++ b/src/bashGPT/Cli/PromptHandler.cs
@@ -62,16 +62,33 @@ public class PromptHandler(
 
         messages.Add(new ChatMessage(ChatRole.User, opts.Prompt));
 
+        var tools = new[] { ToolDefinitions.Bash };
+
         // LLM-Antwort streamen
         Console.WriteLine();
-        var fullResponse = await StreamAndCollectAsync(provider, messages, ct);
+        var firstResponse = await StreamAndCollectAsync(
+            provider,
+            messages,
+            tools,
+            toolChoiceName: "bash",
+            ct);
         Console.WriteLine();
 
-        if (string.IsNullOrWhiteSpace(fullResponse))
+        if (firstResponse.ToolCalls.Count > 0)
+        {
+            if (opts.Verbose)
+                Console.Error.WriteLine($"[verbose] Tool-Calls empfangen: {firstResponse.ToolCalls.Count}");
+            await HandleToolCallsAsync(provider, messages, firstResponse, tools, opts, ct);
+            return 0;
+        }
+
+        if (string.IsNullOrWhiteSpace(firstResponse.Content))
             return 0;
 
         // Bash-Befehle extrahieren und verarbeiten
-        var commands = BashCommandExtractor.Extract(fullResponse);
+        var commands = BashCommandExtractor.Extract(firstResponse.Content);
+        if (opts.Verbose && commands.Count > 0)
+            Console.Error.WriteLine($"[verbose] Fallback aktiv: {commands.Count} Befehl(e) aus Text-Codeblöcken extrahiert");
         if (commands.Count == 0 || opts.ExecMode == ExecutionMode.NoExec)
             return 0;
 
@@ -87,32 +104,48 @@ public class PromptHandler(
             return 0;
 
         var followUp = CommandExecutor.BuildFollowUpContext(results);
-        messages.Add(new ChatMessage(ChatRole.Assistant, fullResponse));
+        messages.Add(new ChatMessage(ChatRole.Assistant, firstResponse.Content));
         messages.Add(new ChatMessage(ChatRole.User, followUp));
 
         if (opts.Verbose)
             Console.Error.WriteLine("[verbose] Follow-up an LLM...");
 
         Console.WriteLine();
-        await StreamAndCollectAsync(provider, messages, ct);
+        await StreamAndCollectAsync(
+            provider,
+            messages,
+            tools,
+            toolChoiceName: "bash",
+            ct);
         Console.WriteLine();
 
         return 0;
     }
 
-    private static async Task<string> StreamAndCollectAsync(
+    private static async Task<LlmChatResponse> StreamAndCollectAsync(
         ILlmProvider provider,
         List<ChatMessage> messages,
+        IReadOnlyList<ToolDefinition> tools,
+        string? toolChoiceName,
         CancellationToken ct)
     {
         var sb = new System.Text.StringBuilder();
+        var response = new LlmChatResponse("", []);
         try
         {
-            await foreach (var token in provider.StreamAsync(messages, ct))
-            {
-                Console.Write(token);
-                sb.Append(token);
-            }
+            response = await provider.ChatAsync(
+                new LlmChatRequest(
+                    Messages: messages,
+                    Tools: tools,
+                    ToolChoiceName: toolChoiceName,
+                    ParallelToolCalls: false,
+                    Stream: true,
+                    OnToken: token =>
+                    {
+                        Console.Write(token);
+                        sb.Append(token);
+                    }),
+                ct);
         }
         catch (LlmProviderException ex)
         {
@@ -122,6 +155,128 @@ public class PromptHandler(
         {
             Console.Error.WriteLine("\nAbgebrochen.");
         }
-        return sb.ToString();
+        return response with { Content = string.IsNullOrEmpty(response.Content) ? sb.ToString() : response.Content };
+    }
+
+    private static async Task HandleToolCallsAsync(
+        ILlmProvider provider,
+        List<ChatMessage> messages,
+        LlmChatResponse initialResponse,
+        IReadOnlyList<ToolDefinition> tools,
+        CliOptions opts,
+        CancellationToken ct)
+    {
+        var response = initialResponse;
+        var rounds = 0;
+
+        while (response.ToolCalls.Count > 0 && rounds < 3)
+        {
+            var toolCalls = response.ToolCalls;
+            if (opts.Verbose)
+                Console.Error.WriteLine($"[verbose] Tool-Call-Runde {rounds + 1}: {toolCalls.Count} Call(s)");
+            var (commands, errors) = ParseToolCalls(toolCalls);
+            if (opts.Verbose)
+            {
+                foreach (var command in commands)
+                    Console.Error.WriteLine($"[verbose] Tool '{command.ToolCall.Name}' -> {command.Command.Command}");
+                foreach (var err in errors)
+                    Console.Error.WriteLine($"[verbose] Tool-Call-Fehler ({err.ToolCall.Name}): {err.Error}");
+            }
+
+            var executor = new CommandExecutor(opts.ExecMode);
+            var results = commands.Count > 0
+                ? await executor.ProcessAsync(commands.Select(c => c.Command).ToList(), ct)
+                : [];
+
+            messages.Add(ChatMessage.AssistantWithToolCalls(toolCalls, response.Content));
+
+            var toolMessages = BuildToolResultMessages(toolCalls, commands, results, errors);
+            foreach (var msg in toolMessages)
+                messages.Add(msg);
+
+            Console.WriteLine();
+            response = await StreamAndCollectAsync(
+                provider,
+                messages,
+                tools,
+                toolChoiceName: "bash",
+                ct);
+            Console.WriteLine();
+
+            rounds++;
+        }
+    }
+
+    private sealed record ParsedToolCommand(ToolCall ToolCall, ExtractedCommand Command);
+    private sealed record ToolCallError(ToolCall ToolCall, string Error);
+
+    private static (List<ParsedToolCommand> Commands, List<ToolCallError> Errors) ParseToolCalls(
+        IReadOnlyList<ToolCall> toolCalls)
+    {
+        var commands = new List<ParsedToolCommand>();
+        var errors = new List<ToolCallError>();
+
+        foreach (var call in toolCalls)
+        {
+            if (!ToolCallParsing.TryGetCommand(call, out var command, out var error))
+            {
+                errors.Add(new ToolCallError(call, error ?? "Unbekannter Fehler."));
+                continue;
+            }
+
+            var (isDangerous, reason) = BashCommandExtractor.CheckDanger(command);
+
+            commands.Add(new ParsedToolCommand(call, new ExtractedCommand(command, isDangerous, reason)));
+        }
+
+        return (commands, errors);
+    }
+
+    private static IReadOnlyList<ChatMessage> BuildToolResultMessages(
+        IReadOnlyList<ToolCall> toolCalls,
+        IReadOnlyList<ParsedToolCommand> commands,
+        IReadOnlyList<CommandResult> results,
+        IReadOnlyList<ToolCallError> errors)
+    {
+        var messages = new List<ChatMessage>();
+
+        var commandResults = results.ToList();
+        for (var i = 0; i < commands.Count; i++)
+        {
+            var call = commands[i].ToolCall;
+            var result = i < commandResults.Count
+                ? commandResults[i]
+                : new CommandResult(commands[i].Command.Command, -1, "Keine Ausführung.", false);
+
+            var content = FormatToolResult(result);
+            messages.Add(ChatMessage.ToolResult(
+                content,
+                toolCallId: call.Id,
+                toolName: call.Name));
+        }
+
+        foreach (var err in errors)
+        {
+            var content = $"Fehler: {err.Error}";
+            messages.Add(ChatMessage.ToolResult(
+                content,
+                toolCallId: err.ToolCall.Id,
+                toolName: err.ToolCall.Name));
+        }
+
+        return messages;
+    }
+
+    private static string FormatToolResult(CommandResult result)
+    {
+        var output = string.IsNullOrWhiteSpace(result.Output)
+            ? "(keine Ausgabe)"
+            : result.Output;
+
+        var status = result.WasExecuted
+            ? $"Exit-Code: {result.ExitCode}"
+            : "Nicht ausgeführt";
+
+        return $"{status}\n{output}";
     }
 }

--- a/src/bashGPT/Providers/CerebrasProvider.cs
+++ b/src/bashGPT/Providers/CerebrasProvider.cs
@@ -9,13 +9,146 @@ namespace BashGPT.Providers;
 
 public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = null) : ILlmProvider
 {
-    private readonly HttpClient _http = httpClient ?? new HttpClient
-    {
-        Timeout = TimeSpan.FromMinutes(5)
-    };
+    private readonly HttpClient _http = httpClient ?? CreateHttpClient();
 
     public string Name  => "Cerebras";
     public string Model => config.Model;
+
+    private static HttpClient CreateHttpClient()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            UseCookies = false
+        };
+
+        return new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromMinutes(5)
+        };
+    }
+
+    public async Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(config.ApiKey))
+            throw new LlmProviderException(
+                "Kein Cerebras API-Key konfiguriert. " +
+                "Setze ihn mit: bashgpt config set cerebras.apiKey <key> " +
+                "oder per Umgebungsvariable BASHGPT_CEREBRAS_KEY.");
+
+        var openAiRequest = new OpenAiChatRequest
+        {
+            Model    = config.Model,
+            Messages = request.Messages.Select(MapMessage).ToList(),
+            Stream   = request.Stream
+        };
+
+        if (request.Tools is { Count: > 0 })
+        {
+            openAiRequest.Tools = request.Tools.Select(MapTool).ToList();
+            openAiRequest.ParallelToolCalls = request.ParallelToolCalls;
+            if (!string.IsNullOrWhiteSpace(request.ToolChoiceName))
+                openAiRequest.ToolChoice = OpenAiToolChoice.ForFunction(request.ToolChoiceName!);
+        }
+
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"{config.BaseUrl.TrimEnd('/')}/chat/completions")
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(openAiRequest, JsonDefaults.Options),
+                Encoding.UTF8, "application/json")
+        };
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", config.ApiKey);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.SendAsync(httpRequest,
+                HttpCompletionOption.ResponseHeadersRead, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new LlmProviderException(
+                $"Cerebras API nicht erreichbar ({config.BaseUrl}): {ex.Message}", ex);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new LlmProviderException("Timeout beim Verbinden mit Cerebras API.", ex);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            var hint = (int)response.StatusCode switch
+            {
+                401 => " → API-Key ungültig oder abgelaufen.",
+                429 => " → Rate-Limit erreicht. Bitte warte kurz.",
+                _   => ""
+            };
+            throw new LlmProviderException(
+                $"Cerebras API antwortete mit HTTP {(int)response.StatusCode}{hint}\n{body}");
+        }
+
+        if (!request.Stream)
+        {
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var full = JsonSerializer.Deserialize<OpenAiChatResponse>(json, JsonDefaults.Options);
+            var message = full?.Choices?.FirstOrDefault()?.Message;
+            var content = message?.Content ?? "";
+            var toolCalls = message?.ToolCalls?.Select(MapToolCall).ToList() ?? [];
+            if (!string.IsNullOrEmpty(content))
+                request.OnToken?.Invoke(content);
+            return new LlmChatResponse(content, toolCalls);
+        }
+
+        var contentBuilder = new StringBuilder();
+        var toolBuilder = new Dictionary<int, ToolCallBuilder>();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new System.IO.StreamReader(stream);
+
+        while (!reader.EndOfStream && !ct.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(ct);
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            if (!line.StartsWith("data:", StringComparison.Ordinal)) continue;
+
+            var json = line["data:".Length..].Trim();
+            if (json == "[DONE]") break;
+
+            OpenAiStreamChunk? chunk;
+            try
+            {
+                chunk = JsonSerializer.Deserialize<OpenAiStreamChunk>(json, JsonDefaults.Options);
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+
+            var delta = chunk?.Choices?.FirstOrDefault()?.Delta;
+            var content = delta?.Content;
+            if (!string.IsNullOrEmpty(content))
+            {
+                request.OnToken?.Invoke(content);
+                contentBuilder.Append(content);
+            }
+
+            if (delta?.ToolCalls is { Count: > 0 })
+            {
+                foreach (var toolDelta in delta.ToolCalls)
+                    ApplyToolDelta(toolBuilder, toolDelta);
+            }
+        }
+
+        var toolCallsFinal = toolBuilder
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => kvp.Value.ToToolCall())
+            .ToList();
+
+        return new LlmChatResponse(contentBuilder.ToString(), toolCallsFinal);
+    }
 
     public async Task<string> CompleteAsync(IEnumerable<ChatMessage> messages, CancellationToken ct = default)
     {
@@ -118,12 +251,27 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
         [JsonPropertyName("model")]    public string Model    { get; set; } = "";
         [JsonPropertyName("messages")] public List<OpenAiMessage> Messages { get; set; } = [];
         [JsonPropertyName("stream")]   public bool   Stream   { get; set; } = true;
+        [JsonPropertyName("tools")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<OpenAiTool>? Tools { get; set; }
+        [JsonPropertyName("tool_choice")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public OpenAiToolChoice? ToolChoice { get; set; }
+        [JsonPropertyName("parallel_tool_calls")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? ParallelToolCalls { get; set; }
     }
 
     private sealed class OpenAiMessage
     {
         [JsonPropertyName("role")]    public string Role    { get; set; } = "";
         [JsonPropertyName("content")] public string Content { get; set; } = "";
+        [JsonPropertyName("tool_calls")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<OpenAiToolCall>? ToolCalls { get; set; }
+        [JsonPropertyName("tool_call_id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ToolCallId { get; set; }
     }
 
     private sealed class OpenAiStreamChunk
@@ -139,5 +287,140 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
     private sealed class OpenAiDelta
     {
         [JsonPropertyName("content")] public string? Content { get; set; }
+        [JsonPropertyName("tool_calls")] public List<OpenAiToolCallDelta>? ToolCalls { get; set; }
+    }
+
+    private sealed class OpenAiChatResponse
+    {
+        [JsonPropertyName("choices")] public List<OpenAiChatChoice>? Choices { get; set; }
+    }
+
+    private sealed class OpenAiChatChoice
+    {
+        [JsonPropertyName("message")] public OpenAiMessage? Message { get; set; }
+    }
+
+    private sealed class OpenAiTool
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = "function";
+        [JsonPropertyName("function")] public OpenAiToolFunction Function { get; set; } = new();
+    }
+
+    private sealed class OpenAiToolFunction
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = "";
+        [JsonPropertyName("description")] public string Description { get; set; } = "";
+        [JsonPropertyName("parameters")] public object Parameters { get; set; } = new();
+    }
+
+    private sealed class OpenAiToolChoice
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = "function";
+        [JsonPropertyName("function")] public OpenAiToolChoiceFunction Function { get; set; } = new();
+
+        public static OpenAiToolChoice ForFunction(string name) =>
+            new() { Function = new OpenAiToolChoiceFunction { Name = name } };
+    }
+
+    private sealed class OpenAiToolChoiceFunction
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = "";
+    }
+
+    private sealed class OpenAiToolCall
+    {
+        [JsonPropertyName("id")] public string Id { get; set; } = "";
+        [JsonPropertyName("type")] public string Type { get; set; } = "function";
+        [JsonPropertyName("function")] public OpenAiToolCallFunction Function { get; set; } = new();
+    }
+
+    private sealed class OpenAiToolCallDelta
+    {
+        [JsonPropertyName("index")] public int Index { get; set; }
+        [JsonPropertyName("id")] public string? Id { get; set; }
+        [JsonPropertyName("type")] public string? Type { get; set; }
+        [JsonPropertyName("function")] public OpenAiToolCallFunction? Function { get; set; }
+    }
+
+    private sealed class OpenAiToolCallFunction
+    {
+        [JsonPropertyName("name")] public string? Name { get; set; }
+        [JsonPropertyName("arguments")] public string? Arguments { get; set; }
+    }
+
+    private sealed class ToolCallBuilder
+    {
+        public string? Id { get; set; }
+        public string? Name { get; set; }
+        public StringBuilder Arguments { get; } = new();
+
+        public int Index { get; init; }
+
+        public ToolCall ToToolCall() =>
+            new(Id, Name ?? "", Arguments.ToString(), Index);
+    }
+
+    private static OpenAiMessage MapMessage(ChatMessage msg)
+    {
+        var message = new OpenAiMessage
+        {
+            Role    = msg.RoleString,
+            Content = msg.Content
+        };
+
+        if (msg.ToolCalls is { Count: > 0 })
+            message.ToolCalls = msg.ToolCalls.Select(MapToolCallDto).ToList();
+
+        if (!string.IsNullOrWhiteSpace(msg.ToolCallId))
+            message.ToolCallId = msg.ToolCallId;
+
+        return message;
+    }
+
+    private static OpenAiTool MapTool(ToolDefinition tool) =>
+        new()
+        {
+            Type = "function",
+            Function = new OpenAiToolFunction
+            {
+                Name        = tool.Name,
+                Description = tool.Description,
+                Parameters  = tool.Parameters
+            }
+        };
+
+    private static OpenAiToolCall MapToolCallDto(ToolCall call) =>
+        new()
+        {
+            Id = call.Id ?? "",
+            Type = "function",
+            Function = new OpenAiToolCallFunction
+            {
+                Name = call.Name,
+                Arguments = call.ArgumentsJson
+            }
+        };
+
+    private static ToolCall MapToolCall(OpenAiToolCall call) =>
+        new(call.Id, call.Function.Name ?? "", call.Function.Arguments ?? "", null);
+
+    private static void ApplyToolDelta(
+        Dictionary<int, ToolCallBuilder> builder,
+        OpenAiToolCallDelta delta)
+    {
+        if (!builder.TryGetValue(delta.Index, out var item))
+        {
+            item = new ToolCallBuilder { Index = delta.Index };
+            builder[delta.Index] = item;
+        }
+
+        if (!string.IsNullOrWhiteSpace(delta.Id))
+            item.Id = delta.Id;
+
+        if (!string.IsNullOrWhiteSpace(delta.Function?.Name))
+            item.Name = delta.Function.Name;
+
+        if (!string.IsNullOrWhiteSpace(delta.Function?.Arguments))
+            item.Arguments.Append(delta.Function.Arguments);
     }
 }

--- a/src/bashGPT/Providers/ChatMessage.cs
+++ b/src/bashGPT/Providers/ChatMessage.cs
@@ -4,16 +4,34 @@ public enum ChatRole
 {
     System,
     User,
-    Assistant
+    Assistant,
+    Tool
 }
 
-public record ChatMessage(ChatRole Role, string Content)
+public record ChatMessage(
+    ChatRole Role,
+    string Content,
+    IReadOnlyList<ToolCall>? ToolCalls = null,
+    string? ToolCallId = null,
+    string? ToolName = null)
 {
     public string RoleString => Role switch
     {
         ChatRole.System    => "system",
         ChatRole.User      => "user",
         ChatRole.Assistant => "assistant",
+        ChatRole.Tool      => "tool",
         _                  => throw new ArgumentOutOfRangeException()
     };
+
+    public static ChatMessage AssistantWithToolCalls(
+        IReadOnlyList<ToolCall> toolCalls,
+        string content = "") =>
+        new(ChatRole.Assistant, content, ToolCalls: toolCalls);
+
+    public static ChatMessage ToolResult(
+        string content,
+        string? toolCallId = null,
+        string? toolName = null) =>
+        new(ChatRole.Tool, content, ToolCalls: null, ToolCallId: toolCallId, ToolName: toolName);
 }

--- a/src/bashGPT/Providers/ILlmProvider.cs
+++ b/src/bashGPT/Providers/ILlmProvider.cs
@@ -5,6 +5,10 @@ public interface ILlmProvider
     string Name { get; }
     string Model { get; }
 
+    Task<LlmChatResponse> ChatAsync(
+        LlmChatRequest request,
+        CancellationToken ct = default);
+
     Task<string> CompleteAsync(
         IEnumerable<ChatMessage> messages,
         CancellationToken ct = default);

--- a/src/bashGPT/Providers/OllamaProvider.cs
+++ b/src/bashGPT/Providers/OllamaProvider.cs
@@ -8,13 +8,126 @@ namespace BashGPT.Providers;
 
 public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) : ILlmProvider
 {
-    private readonly HttpClient _http = httpClient ?? new HttpClient
-    {
-        Timeout = TimeSpan.FromMinutes(5)
-    };
+    private readonly HttpClient _http = httpClient ?? CreateHttpClient();
 
     public string Name  => "Ollama";
     public string Model => config.Model;
+
+    private static HttpClient CreateHttpClient()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            UseCookies = false
+        };
+
+        return new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromMinutes(5)
+        };
+    }
+
+    public async Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
+    {
+        var ollamaRequest = new OllamaChatRequest
+        {
+            Model    = config.Model,
+            Messages = request.Messages.Select(MapMessage).ToList(),
+            Stream   = request.Stream
+        };
+
+        if (request.Tools is { Count: > 0 })
+            ollamaRequest.Tools = request.Tools.Select(MapTool).ToList();
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.PostAsJsonAsync(
+                $"{config.BaseUrl.TrimEnd('/')}/api/chat", ollamaRequest, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new LlmProviderException(
+                $"Ollama ist nicht erreichbar unter '{config.BaseUrl}'. " +
+                $"Läuft 'ollama serve'? (Details: {ex.Message})", ex);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new LlmProviderException(
+                $"Timeout beim Verbinden mit Ollama ({config.BaseUrl}).", ex);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            throw new LlmProviderException(
+                $"Ollama antwortete mit HTTP {(int)response.StatusCode}: {body}");
+        }
+
+        if (!request.Stream)
+        {
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var full = JsonSerializer.Deserialize<OllamaChatResponse>(json, JsonDefaults.Options);
+            var content = full?.Message?.Content ?? "";
+            var toolCalls = full?.Message?.ToolCalls?.Select(MapToolCall).ToList() ?? [];
+            if (!string.IsNullOrEmpty(content))
+                request.OnToken?.Invoke(content);
+            return new LlmChatResponse(content, toolCalls);
+        }
+
+        var contentBuilder = new System.Text.StringBuilder();
+        var toolCallsByIndex = new Dictionary<int, ToolCall>();
+        var toolCallsNoIndex = new List<ToolCall>();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new System.IO.StreamReader(stream);
+
+        while (!reader.EndOfStream && !ct.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(ct);
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            OllamaChatResponse? chunk;
+            try
+            {
+                chunk = JsonSerializer.Deserialize<OllamaChatResponse>(line, JsonDefaults.Options);
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+
+            if (chunk is null) continue;
+
+            var content = chunk.Message?.Content;
+            if (!string.IsNullOrEmpty(content))
+            {
+                request.OnToken?.Invoke(content);
+                contentBuilder.Append(content);
+            }
+
+            if (chunk.Message?.ToolCalls is { Count: > 0 })
+            {
+                foreach (var tc in chunk.Message.ToolCalls)
+                {
+                    var mapped = MapToolCall(tc);
+                    if (mapped.Index is int idx)
+                        toolCallsByIndex[idx] = mapped;
+                    else
+                        toolCallsNoIndex.Add(mapped);
+                }
+            }
+
+            if (chunk.Done) break;
+        }
+
+        var ordered = toolCallsByIndex
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => kvp.Value)
+            .Concat(toolCallsNoIndex)
+            .ToList();
+
+        return new LlmChatResponse(contentBuilder.ToString(), ordered);
+    }
 
     public async Task<string> CompleteAsync(IEnumerable<ChatMessage> messages, CancellationToken ct = default)
     {
@@ -95,12 +208,21 @@ public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) 
         [JsonPropertyName("model")]    public string Model    { get; set; } = "";
         [JsonPropertyName("messages")] public List<OllamaMessage> Messages { get; set; } = [];
         [JsonPropertyName("stream")]   public bool   Stream   { get; set; } = true;
+        [JsonPropertyName("tools")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<OllamaTool>? Tools { get; set; }
     }
 
     private sealed class OllamaMessage
     {
         [JsonPropertyName("role")]    public string Role    { get; set; } = "";
         [JsonPropertyName("content")] public string Content { get; set; } = "";
+        [JsonPropertyName("tool_calls")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<OllamaToolCall>? ToolCalls { get; set; }
+        [JsonPropertyName("tool_name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ToolName { get; set; }
     }
 
     private sealed class OllamaChatResponse
@@ -108,4 +230,99 @@ public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) 
         [JsonPropertyName("message")] public OllamaMessage? Message { get; set; }
         [JsonPropertyName("done")]    public bool Done               { get; set; }
     }
+
+    private sealed class OllamaTool
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = "function";
+        [JsonPropertyName("function")] public OllamaToolFunction Function { get; set; } = new();
+    }
+
+    private sealed class OllamaToolFunction
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = "";
+        [JsonPropertyName("description")] public string Description { get; set; } = "";
+        [JsonPropertyName("parameters")] public object Parameters { get; set; } = new();
+    }
+
+    private sealed class OllamaToolCall
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = "function";
+        [JsonPropertyName("function")] public OllamaToolCallFunction Function { get; set; } = new();
+    }
+
+    private sealed class OllamaToolCallFunction
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = "";
+        [JsonPropertyName("arguments")] public JsonElement Arguments { get; set; }
+        [JsonPropertyName("index")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? Index { get; set; }
+    }
+
+    private static OllamaMessage MapMessage(ChatMessage msg)
+    {
+        var message = new OllamaMessage
+        {
+            Role    = msg.RoleString,
+            Content = msg.Content
+        };
+
+        if (msg.ToolCalls is { Count: > 0 })
+            message.ToolCalls = msg.ToolCalls.Select(MapToolCallDto).ToList();
+
+        if (!string.IsNullOrWhiteSpace(msg.ToolName))
+            message.ToolName = msg.ToolName;
+
+        return message;
+    }
+
+    private static OllamaTool MapTool(ToolDefinition tool) =>
+        new()
+        {
+            Type = "function",
+            Function = new OllamaToolFunction
+            {
+                Name        = tool.Name,
+                Description = tool.Description,
+                Parameters  = tool.Parameters
+            }
+        };
+
+    private static OllamaToolCall MapToolCallDto(ToolCall call)
+    {
+        var args = TryParseJson(call.ArgumentsJson, out var element)
+            ? element
+            : JsonSerializer.Deserialize<JsonElement>("{\"command\":\"" + EscapeJson(call.ArgumentsJson) + "\"}");
+
+        return new OllamaToolCall
+        {
+            Type = "function",
+            Function = new OllamaToolCallFunction
+            {
+                Name = call.Name,
+                Arguments = args,
+                Index = call.Index
+            }
+        };
+    }
+
+    private static ToolCall MapToolCall(OllamaToolCall call) =>
+        new(null, call.Function.Name, call.Function.Arguments.GetRawText(), call.Function.Index);
+
+    private static bool TryParseJson(string input, out JsonElement element)
+    {
+        try
+        {
+            element = JsonSerializer.Deserialize<JsonElement>(input);
+            return true;
+        }
+        catch (JsonException)
+        {
+            element = default;
+            return false;
+        }
+    }
+
+    private static string EscapeJson(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
 }

--- a/src/bashGPT/Providers/Tooling.cs
+++ b/src/bashGPT/Providers/Tooling.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+
+namespace BashGPT.Providers;
+
+public record ToolDefinition(string Name, string Description, object Parameters);
+
+public static class ToolDefinitions
+{
+    public static readonly ToolDefinition Bash = new(
+        Name: "bash",
+        Description: "Führt einen Shell-Befehl aus",
+        Parameters: new
+        {
+            type = "object",
+            properties = new
+            {
+                command = new
+                {
+                    type = "string",
+                    description = "Shell-Befehl"
+                }
+            },
+            required = new[] { "command" }
+        });
+}
+
+public record ToolCall(string? Id, string Name, string ArgumentsJson, int? Index = null);
+
+public record LlmChatRequest(
+    IReadOnlyList<ChatMessage> Messages,
+    IReadOnlyList<ToolDefinition>? Tools = null,
+    string? ToolChoiceName = null,
+    bool? ParallelToolCalls = null,
+    bool Stream = true,
+    Action<string>? OnToken = null);
+
+public record LlmChatResponse(
+    string Content,
+    IReadOnlyList<ToolCall> ToolCalls);
+
+internal static class ToolCallParsing
+{
+    public static bool TryGetCommand(ToolCall call, out string command, out string? error)
+    {
+        command = "";
+        error = null;
+
+        if (!call.Name.Equals("bash", StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"Unbekanntes Tool '{call.Name}'.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(call.ArgumentsJson))
+        {
+            error = "Leere Tool-Argumente.";
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(call.ArgumentsJson);
+            if (!doc.RootElement.TryGetProperty("command", out var cmdEl))
+            {
+                error = "Tool-Argumente enthalten kein Feld 'command'.";
+                return false;
+            }
+
+            if (cmdEl.ValueKind != JsonValueKind.String)
+            {
+                error = "Tool-Argument 'command' ist kein String.";
+                return false;
+            }
+
+            command = cmdEl.GetString() ?? "";
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                error = "Tool-Argument 'command' ist leer.";
+                return false;
+            }
+
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            error = $"Ungültiges JSON in Tool-Argumenten: {ex.Message}";
+            return false;
+        }
+    }
+}

--- a/src/bashGPT/Shell/BashCommandExtractor.cs
+++ b/src/bashGPT/Shell/BashCommandExtractor.cs
@@ -58,7 +58,7 @@ public static class BashCommandExtractor
         return results;
     }
 
-    private static (bool IsDangerous, string? Reason) CheckDanger(string command)
+    public static (bool IsDangerous, string? Reason) CheckDanger(string command)
     {
         foreach (var (pattern, reason) in DangerPatterns)
         {


### PR DESCRIPTION
## Summary
- add provider-agnostic tool-calling primitives and a single `bash` tool definition
- add tool-aware chat request/response handling for Cerebras and Ollama
- execute returned `bash` tool calls locally and send tool results back to the model
- add verbose diagnostics to distinguish tool-calling from text-extraction fallback
- harden HTTP client construction with cookies disabled to avoid runtime cookie container issues

## Validation
- manual run with Cerebras + `--auto-exec --verbose` confirmed multi-round `bash` tool calls

Closes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unterstützung für Tool-gestützte Antworten mit Bash-Befehlsausführung hinzugefügt
  * Mehrere Tool-Call-Runden (bis zu 3) pro Anfrage ermöglicht
  * Neue Chat-API mit Streaming- und Tool-Handling implementiert
  * Erweiterte Unterstützung für LLM-Provider (Cerebras, Ollama)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->