### PR TITLE
feat(chat-ui): Tool-Calls, Command-Output und Exec-Mode sichtbar machen

### DIFF
--- a/src/bashGPT.Web/src/components/chat-app.ts
+++ b/src/bashGPT.Web/src/components/chat-app.ts
@@ -6,6 +6,7 @@ import './sidebar'
 import './dashboard'
 import './settings-view'
 import './chat-view'
+import './terminal-panel'
 import { sendChat, loadHistory, resetHistory, getSessions } from '../api'
 import type { AppView, ExecMode, CommandResult, Session } from '../types'
 
@@ -419,6 +420,7 @@ export class ChatApp extends LitElement {
           <bashgpt-chat-view
             style="display: ${this._view === 'chat' ? 'flex' : 'none'}; flex-direction: column; height: 100%;"
             pendingPrompt=${this._pendingPrompt}
+            ?showTerminal=${true}
             @chat-started=${this._onChatStarted}
           ></bashgpt-chat-view>
         </div>

--- a/src/bashGPT.Web/src/components/chat-view.ts
+++ b/src/bashGPT.Web/src/components/chat-view.ts
@@ -2,13 +2,15 @@ import { LitElement, html, css } from 'lit'
 import { customElement, state, property } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
 import './message-bubble'
+import './terminal-panel'
 import { sendChat, loadHistory, resetHistory } from '../api'
-import type { ExecMode, CommandResult } from '../types'
+import type { ExecMode, CommandResult, TerminalEntry } from '../types'
 
 interface Message {
   id: number
   role: 'user' | 'assistant'
   content: string
+  execMode?: ExecMode
   commands?: CommandResult[]
   usedToolCalls?: boolean
 }
@@ -17,12 +19,15 @@ interface Message {
 export class ChatView extends LitElement {
   /** Wird von außen gesetzt (Dashboard-Prompt) – löst sofortigen Send aus */
   @property() pendingPrompt = ''
+  /** v2-Modus: zeigt Terminal-Panel links neben dem Chat */
+  @property({ type: Boolean }) showTerminal = false
 
   @state() private _messages: Message[] = []
   @state() private _loading = false
-  @state() private _status = ''
+  @state() private _statusText = ''
   @state() private _statusError = false
   @state() private _mode: ExecMode = 'ask'
+  @state() private _terminalOpen = true
   private _idCounter = 0
 
   static styles = css`
@@ -33,6 +38,31 @@ export class ChatView extends LitElement {
       overflow: hidden;
     }
 
+    /* ── Split layout ───────────────────────────────────────────────────── */
+    .split-wrapper {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+    }
+
+    bashgpt-terminal-panel {
+      width: 280px;
+      flex-shrink: 0;
+      transition: width 0.2s ease;
+    }
+    bashgpt-terminal-panel.collapsed {
+      width: 0;
+      overflow: hidden;
+    }
+
+    .chat-column {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* ── Chat area ──────────────────────────────────────────────────────── */
     #chat {
       flex: 1;
       overflow-y: auto;
@@ -55,6 +85,28 @@ export class ChatView extends LitElement {
     .empty-state .icon { font-size: 40px; }
     .empty-state p { font-size: 15px; }
 
+    /* ── Working indicator bar ──────────────────────────────────────────── */
+    .working-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 20px;
+      background: #0b1a2e;
+      border-top: 1px solid #1e3a5f;
+      font-size: 12px;
+      color: #60a5fa;
+      flex-shrink: 0;
+    }
+    .working-bar .spinner {
+      width: 12px; height: 12px;
+      border: 1.5px solid #1e3a5f;
+      border-top-color: #60a5fa;
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Footer ─────────────────────────────────────────────────────────── */
     footer {
       padding: 10px 16px 16px;
       border-top: 1px solid #1e293b;
@@ -63,11 +115,7 @@ export class ChatView extends LitElement {
       flex-shrink: 0;
     }
 
-    .input-row {
-      display: flex;
-      gap: 8px;
-      align-items: flex-end;
-    }
+    .input-row { display: flex; gap: 8px; align-items: flex-end; }
 
     textarea {
       flex: 1;
@@ -87,12 +135,14 @@ export class ChatView extends LitElement {
     }
     textarea:focus { border-color: #4b5563; }
     textarea::placeholder { color: #4b5563; }
+    textarea:disabled { opacity: 0.5; }
 
     .controls {
       display: flex;
       gap: 8px;
       margin-top: 8px;
       align-items: center;
+      flex-wrap: wrap;
     }
 
     select {
@@ -115,6 +165,7 @@ export class ChatView extends LitElement {
       font-size: 13px;
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
+      font-family: inherit;
     }
     button:hover:not(:disabled) { background: #1f2937; border-color: #4b5563; }
     button:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -128,6 +179,13 @@ export class ChatView extends LitElement {
     }
     button.primary:hover:not(:disabled) { background: #166534; }
 
+    button.terminal-toggle {
+      padding: 7px 10px;
+      font-size: 12px;
+      color: #64748b;
+    }
+    button.terminal-toggle.active { color: #22c55e; border-color: #166534; }
+
     .status {
       font-size: 12px;
       color: #4b5563;
@@ -136,18 +194,11 @@ export class ChatView extends LitElement {
     }
     .status.error { color: #ef4444; }
 
-    .spinner {
-      display: inline-block;
-      width: 12px;
-      height: 12px;
-      border: 2px solid #374151;
-      border-top-color: #22c55e;
-      border-radius: 50%;
-      animation: spin 0.7s linear infinite;
-      vertical-align: middle;
-      margin-right: 4px;
+    /* ── Mobile ─────────────────────────────────────────────────────────── */
+    @media (max-width: 768px) {
+      bashgpt-terminal-panel { width: 100%; border-right: none; border-bottom: 1px solid #1e293b; }
+      .split-wrapper { flex-direction: column; }
     }
-    @keyframes spin { to { transform: rotate(360deg); } }
   `
 
   async connectedCallback() {
@@ -161,10 +212,23 @@ export class ChatView extends LitElement {
     }
   }
 
-  /** Öffentliche Methode für Shell: History neu laden (nach Session-Wechsel) */
+  /** Öffentlich: History neu laden (nach Session-Wechsel) */
   async reloadHistory() {
     this._messages = []
     await this._loadHistory()
+  }
+
+  /** Öffentlich: Session zurücksetzen */
+  async reset() {
+    try {
+      await resetHistory()
+      this._messages = []
+      this._statusText = 'Verlauf gelöscht'
+      this._statusError = false
+    } catch (e) {
+      this._statusText = `Fehler: ${e instanceof Error ? e.message : String(e)}`
+      this._statusError = true
+    }
   }
 
   private async _loadHistory() {
@@ -178,26 +242,26 @@ export class ChatView extends LitElement {
       this._statusError = false
     } catch (e) {
       this._statusError = true
-      this._status = `Fehler: ${e instanceof Error ? e.message : String(e)}`
+      this._statusText = `Fehler: ${e instanceof Error ? e.message : String(e)}`
     }
   }
 
   private async _sendPrompt(prompt: string) {
     if (!prompt.trim() || this._loading) return
 
+    const execMode = this._mode
     this._messages = [
       ...this._messages,
-      { id: this._idCounter++, role: 'user', content: prompt },
+      { id: this._idCounter++, role: 'user', content: prompt, execMode },
     ]
     this._loading = true
-    this._status = ''
+    this._statusText = ''
     this._statusError = false
     this._scrollToBottom()
-    // Signal nach oben, damit Shell zum Chat-View wechselt
     this.dispatchEvent(new CustomEvent('chat-started', { bubbles: true, composed: true }))
 
     try {
-      const result = await sendChat(prompt, this._mode)
+      const result = await sendChat(prompt, execMode)
       this._messages = [
         ...this._messages,
         {
@@ -210,15 +274,15 @@ export class ChatView extends LitElement {
       ]
       const parts = [`tool_calls=${result.usedToolCalls ? 'ja' : 'nein'}`]
       if (result.commands.length > 0)
-        parts.push(`${result.commands.length} Befehle`)
-      this._status = parts.join(' · ')
+        parts.push(`${result.commands.length} Befehl${result.commands.length > 1 ? 'e' : ''}`)
+      this._statusText = parts.join(' · ')
       this._statusError = false
     } catch (e) {
-      this._status = `Fehler: ${e instanceof Error ? e.message : String(e)}`
+      this._statusText = `Fehler: ${e instanceof Error ? e.message : String(e)}`
       this._statusError = true
       this._messages = [
         ...this._messages,
-        { id: this._idCounter++, role: 'assistant', content: `⚠️ ${this._status}` },
+        { id: this._idCounter++, role: 'assistant', content: `⚠️ ${this._statusText}` },
       ]
     } finally {
       this._loading = false
@@ -232,18 +296,6 @@ export class ChatView extends LitElement {
     if (!prompt) return
     textarea.value = ''
     await this._sendPrompt(prompt)
-  }
-
-  async reset() {
-    try {
-      await resetHistory()
-      this._messages = []
-      this._status = 'Verlauf gelöscht'
-      this._statusError = false
-    } catch (e) {
-      this._status = `Fehler: ${e instanceof Error ? e.message : String(e)}`
-      this._statusError = true
-    }
   }
 
   private _scrollToBottom() {
@@ -260,30 +312,81 @@ export class ChatView extends LitElement {
     }
   }
 
+  /** Aggregiert alle CommandResults aus allen Nachrichten als TerminalEntries */
+  private get _terminalEntries(): TerminalEntry[] {
+    const entries: TerminalEntry[] = []
+    for (const msg of this._messages) {
+      if (msg.role !== 'assistant' || !msg.commands?.length) continue
+      for (const cmd of msg.commands) {
+        let status: TerminalEntry['status']
+        if (!cmd.wasExecuted) status = 'skipped'
+        else if (cmd.exitCode === 0) status = 'success'
+        else status = 'error'
+        entries.push({
+          command: cmd.command,
+          output: cmd.output,
+          exitCode: cmd.exitCode,
+          wasExecuted: cmd.wasExecuted,
+          status,
+        })
+      }
+    }
+    return entries
+  }
+
+  private _workingText() {
+    if (!this._loading) return ''
+    const last = this._messages.at(-1)
+    // Wenn letzter Eintrag vom User kommt, sind wir noch in der LLM-Phase
+    return last?.role === 'user' ? 'Denke…' : 'Verarbeite Tool-Ergebnis…'
+  }
+
   render() {
     const isEmpty = this._messages.length === 0
+    const workingText = this._workingText()
+    const showPanel = this.showTerminal && this._terminalOpen
 
     return html`
-      <div id="chat">
-        ${isEmpty
-          ? html`
-              <div class="empty-state">
-                <div class="icon">⌨️</div>
-                <p>Stell mir eine Frage oder wähle einen Use-Case.</p>
-              </div>
-            `
-          : repeat(
-              this._messages,
-              m => m.id,
-              m => html`
-                <bashgpt-message
-                  role=${m.role}
-                  content=${m.content}
-                  .commands=${m.commands ?? []}
-                  ?usedToolCalls=${m.usedToolCalls ?? false}
-                ></bashgpt-message>
-              `
-            )}
+      <div class="split-wrapper">
+        ${this.showTerminal ? html`
+          <bashgpt-terminal-panel
+            class="${showPanel ? '' : 'collapsed'}"
+            .entries=${this._terminalEntries}
+            ?loading=${this._loading}
+          ></bashgpt-terminal-panel>
+        ` : ''}
+
+        <div class="chat-column">
+          <div id="chat">
+            ${isEmpty
+              ? html`
+                  <div class="empty-state">
+                    <div class="icon">⌨️</div>
+                    <p>Stell mir eine Frage oder wähle einen Use-Case.</p>
+                  </div>
+                `
+              : repeat(
+                  this._messages,
+                  m => m.id,
+                  m => html`
+                    <bashgpt-message
+                      role=${m.role}
+                      content=${m.content}
+                      execMode=${m.execMode ?? ''}
+                      .commands=${m.commands ?? []}
+                      ?usedToolCalls=${m.usedToolCalls ?? false}
+                    ></bashgpt-message>
+                  `
+                )}
+          </div>
+
+          ${this._loading ? html`
+            <div class="working-bar">
+              <div class="spinner"></div>
+              ${workingText}
+            </div>
+          ` : ''}
+        </div>
       </div>
 
       <footer>
@@ -305,11 +408,19 @@ export class ChatView extends LitElement {
             <option value="auto-exec">auto-exec</option>
             <option value="no-exec">no-exec</option>
           </select>
+
+          ${this.showTerminal ? html`
+            <button
+              class="terminal-toggle ${this._terminalOpen ? 'active' : ''}"
+              @click=${() => { this._terminalOpen = !this._terminalOpen }}
+              title="Terminal ein-/ausblenden"
+            >⌃ Terminal</button>
+          ` : ''}
+
           <span class="status ${this._statusError ? 'error' : ''}">
-            ${this._loading
-              ? html`<span class="spinner"></span> Denke…`
-              : this._status}
+            ${this._statusText}
           </span>
+
           <button class="primary" @click=${this._send} ?disabled=${this._loading}>
             Senden
           </button>

--- a/src/bashGPT.Web/src/components/message-bubble.ts
+++ b/src/bashGPT.Web/src/components/message-bubble.ts
@@ -5,7 +5,7 @@ import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 import hljs from 'highlight.js'
 import hljsStyles from 'highlight.js/styles/github-dark.css?inline'
-import type { CommandResult } from '../types'
+import type { CommandResult, ExecMode } from '../types'
 
 marked.setOptions({
   async: false,
@@ -23,6 +23,7 @@ marked.use({ renderer })
 export class MessageBubble extends LitElement {
   @property() role: 'user' | 'assistant' = 'user'
   @property() content = ''
+  @property() execMode: ExecMode | '' = ''
   @property({ type: Array }) commands: CommandResult[] = []
   @property({ type: Boolean }) usedToolCalls = false
   @property({ type: Array }) logs: string[] = []
@@ -148,6 +149,25 @@ export class MessageBubble extends LitElement {
         color: #a78bfa;
         margin-top: 6px;
       }
+
+      /* Exec-mode badge */
+      .meta-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+      .exec-badge {
+        font-size: 10px;
+        font-weight: 600;
+        padding: 1px 7px;
+        border-radius: 999px;
+        letter-spacing: 0.03em;
+      }
+      .exec-ask       { background: #1e3a5f; color: #60a5fa; }
+      .exec-dry-run   { background: #3b2f00; color: #fcd34d; }
+      .exec-auto-exec { background: #14532d; color: #86efac; }
+      .exec-no-exec   { background: #1e293b; color: #64748b; }
     `,
   ]
 
@@ -175,10 +195,22 @@ export class MessageBubble extends LitElement {
     `
   }
 
+  private _execBadge() {
+    if (this.role !== 'user' || !this.execMode) return ''
+    const label: Record<string, string> = {
+      'ask': 'ask', 'dry-run': 'dry-run', 'auto-exec': 'auto-exec', 'no-exec': 'no-exec',
+    }
+    const cls = `exec-${this.execMode}`
+    return html`<span class="exec-badge ${cls}">${label[this.execMode]}</span>`
+  }
+
   render() {
     return html`
       <div class="bubble ${this.role}">
-        <div class="meta">${this.role === 'user' ? 'Du' : 'bashGPT'}</div>
+        <div class="meta-row">
+          <span class="meta">${this.role === 'user' ? 'Du' : 'bashGPT'}</span>
+          ${this._execBadge()}
+        </div>
         <div class="content">${this._html}</div>
         ${this.usedToolCalls
           ? html`<div class="tool-badge">⚡ Tool-Calls verwendet</div>`

--- a/src/bashGPT.Web/src/components/terminal-panel.ts
+++ b/src/bashGPT.Web/src/components/terminal-panel.ts
@@ -1,0 +1,194 @@
+import { LitElement, html, css } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { repeat } from 'lit/directives/repeat.js'
+import type { TerminalEntry } from '../types'
+
+@customElement('bashgpt-terminal-panel')
+export class TerminalPanel extends LitElement {
+  @property({ type: Array }) entries: TerminalEntry[] = []
+  @property({ type: Boolean }) loading = false
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      background: #020617;
+      border-right: 1px solid #1e293b;
+      font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+      font-size: 12px;
+      overflow: hidden;
+    }
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      border-bottom: 1px solid #1e293b;
+      background: #0b1120;
+      flex-shrink: 0;
+    }
+    .panel-title {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: #475569;
+      flex: 1;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; }
+    .dot-red    { background: #ef4444; }
+    .dot-yellow { background: #f59e0b; }
+    .dot-green  { background: #22c55e; }
+
+    .entries {
+      flex: 1;
+      overflow-y: auto;
+      padding: 10px 0 16px;
+    }
+
+    .empty {
+      padding: 20px 16px;
+      color: #334155;
+      font-size: 12px;
+      font-style: italic;
+    }
+
+    .entry {
+      padding: 6px 12px 10px;
+      border-bottom: 1px solid #0f172a;
+    }
+    .entry:last-child { border-bottom: none; }
+
+    .prompt-line {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 4px;
+    }
+    .prompt-sign {
+      color: #22c55e;
+      font-weight: 700;
+      user-select: none;
+    }
+    .cmd-text {
+      color: #f1f5f9;
+      word-break: break-all;
+    }
+
+    .status-badge {
+      margin-left: auto;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 1px 6px;
+      border-radius: 999px;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .badge-running  { background: #1e3a5f; color: #60a5fa; }
+    .badge-success  { background: #14532d; color: #86efac; }
+    .badge-error    { background: #7f1d1d; color: #fca5a5; }
+    .badge-skipped  { background: #1e293b; color: #64748b; }
+
+    .output {
+      color: #94a3b8;
+      white-space: pre-wrap;
+      word-break: break-all;
+      margin-left: 16px;
+      max-height: 180px;
+      overflow-y: auto;
+      line-height: 1.5;
+    }
+    .output.error { color: #f87171; }
+    .output.skipped { color: #475569; font-style: italic; }
+
+    .running-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      color: #60a5fa;
+      margin-left: 16px;
+      margin-top: 4px;
+    }
+    .spinner {
+      width: 10px; height: 10px;
+      border: 1.5px solid #1e3a5f;
+      border-top-color: #60a5fa;
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  `
+
+  updated() {
+    const el = this.shadowRoot?.querySelector('.entries')
+    if (el) el.scrollTop = el.scrollHeight
+  }
+
+  private _badgeClass(s: TerminalEntry['status']) {
+    return { running: 'badge-running', success: 'badge-success', error: 'badge-error', skipped: 'badge-skipped' }[s]
+  }
+
+  private _badgeLabel(s: TerminalEntry['status']) {
+    return { running: '●  läuft', success: 'exit 0', error: `exit ${0}`, skipped: 'übersprungen' }[s]
+  }
+
+  private _outputClass(e: TerminalEntry) {
+    if (e.status === 'skipped') return 'skipped'
+    if (e.status === 'error')   return 'error'
+    return ''
+  }
+
+  render() {
+    const hasEntries = this.entries.length > 0 || this.loading
+
+    return html`
+      <div class="panel-header">
+        <div class="dot dot-red"></div>
+        <div class="dot dot-yellow"></div>
+        <div class="dot dot-green"></div>
+        <div class="panel-title">Terminal</div>
+      </div>
+
+      <div class="entries">
+        ${!hasEntries
+          ? html`<div class="empty">Noch keine Befehle ausgeführt.</div>`
+          : ''}
+
+        ${repeat(
+          this.entries,
+          (_e, i) => i,
+          e => {
+            const badgeLabel = e.status === 'error'
+              ? `exit ${e.exitCode}`
+              : this._badgeLabel(e.status)
+            return html`
+              <div class="entry">
+                <div class="prompt-line">
+                  <span class="prompt-sign">$</span>
+                  <span class="cmd-text">${e.command}</span>
+                  <span class="status-badge ${this._badgeClass(e.status)}">${badgeLabel}</span>
+                </div>
+                ${e.status === 'running'
+                  ? html`<div class="running-indicator"><div class="spinner"></div> läuft…</div>`
+                  : e.output
+                    ? html`<div class="output ${this._outputClass(e)}">${e.output}</div>`
+                    : ''}
+              </div>
+            `
+          }
+        )}
+
+        ${this.loading && this.entries.every(e => e.status !== 'running')
+          ? html`
+              <div class="entry">
+                <div class="running-indicator">
+                  <div class="spinner"></div> Denke…
+                </div>
+              </div>
+            `
+          : ''}
+      </div>
+    `
+  }
+}


### PR DESCRIPTION
## Summary

- Neuer `<bashgpt-terminal-panel>` neben dem Chat: zeigt alle ausgeführten Befehle mit Terminal-Styling (grüner Prompt, Status-Badges, Output, Auto-Scroll)
- `<bashgpt-message>` zeigt pro User-Nachricht ein Exec-Mode-Badge (ask / dry-run / auto-exec / no-exec)
- `<bashgpt-chat-view>` Split-Layout: Terminal-Panel (280 px, per Toggle-Button ein-/ausblendbar) links, Chat-Spalte rechts
- Working-Bar unterscheidet "Denke…" (LLM arbeitet) vs. "Verarbeite Tool-Ergebnis…" (zweiter Loop-Durchlauf)
- `_terminalEntries` ist ein berechneter Getter aus `_messages` – kein separater State nötig
- `<bashgpt-chat-app>` aktiviert `showTerminal` automatisch im v2-Modus

## Test plan

- [ ] v2-UI aktivieren (`bashgpt_ui_v2=true` in localStorage)
- [ ] Chat öffnen, Nachricht im Modus `auto-exec` oder `ask` senden
- [ ] Terminal-Panel links zeigt Befehle mit korrektem Status (exit 0 / exit N / übersprungen)
- [ ] User-Nachricht trägt korrektes Exec-Mode-Badge
- [ ] Working-Bar wechselt korrekt zwischen "Denke…" und "Verarbeite Tool-Ergebnis…"
- [ ] Terminal-Toggle-Button blendet Panel ein/aus
- [ ] Responsive: auf Mobile (<768 px) stapelt sich das Panel über dem Chat

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Funktionen

* **Terminal-Panel-Integration** – Neue V2 UI mit Terminal-Ansicht neben dem Chat zur Anzeige von Befehlsergebnissen
* **Chat-Reset-Funktion** – Neue Reset-Schaltfläche zum Löschen des Chatverlaufs
* **Ausführungsmodus-Anzeige** – Neue Badges in Nachrichten zur Anzeige des Ausführungsmodus
* **Toggle Terminal-Sichtbarkeit** – Neue Schaltfläche zum Ein-/Ausblenden des Terminal-Panels
* **Responsive Mobile-Layout** – Verbesserte Ansicht für mobile Geräte mit vertikalem Stapel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->