### PR TITLE
test(ui): E2E- und Regressionschecks für Server-UI v2 aufbauen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/bashGPT.Web/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: src/bashGPT.Web
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: src/bashGPT.Web
+        run: npm run build
+
+      - name: Restore .NET dependencies
+        run: dotnet restore
+
+      - name: Build .NET solution
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run tests
+        run: dotnet test --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: '**/test-results.trx'

--- a/docs/testing/runbook-server-ui.md
+++ b/docs/testing/runbook-server-ui.md
@@ -1,0 +1,148 @@
+# Testrunbook: Server-UI v2 (Issue #21)
+
+## Überblick
+
+Die Server-UI-Tests sind als **Integration-Tests** im Projekt `tests/bashGPT.Tests`
+unter `Server/` implementiert. Sie starten den echten `ServerHost`-HTTP-Listener auf
+einem zufälligen Port und testen alle API-Endpunkte ohne echte LLM-Verbindung, indem
+ein `FakePromptHandler`-Stub injiziert wird.
+
+---
+
+## Lokaler Testlauf
+
+### Voraussetzungen
+
+- .NET SDK 9.0
+- Node.js 20+ (für Frontend-Build, der dem .NET-Build vorgelagert ist)
+
+### Alle Tests ausführen
+
+```bash
+# im Root-Verzeichnis des Repos
+dotnet test
+```
+
+### Nur Server-UI-Tests ausführen
+
+```bash
+dotnet test --filter "FullyQualifiedName~ServerHost"
+```
+
+### Mit ausführlicher Ausgabe
+
+```bash
+dotnet test --filter "FullyQualifiedName~ServerHost" --logger "console;verbosity=normal"
+```
+
+---
+
+## Testfälle
+
+### GET /
+
+| Test | Erwartetes Ergebnis |
+|------|---------------------|
+| `Get_Root_Returns200WithHtml` | Status 200, Content-Type `text/html` |
+
+### GET /bundle.js
+
+| Test | Erwartetes Ergebnis |
+|------|---------------------|
+| `Get_BundleJs_Returns200WithJavaScript` | Status 200, Content-Type `application/javascript` |
+
+### GET /api/history
+
+| Test | Erwartetes Ergebnis |
+|------|---------------------|
+| `Get_History_InitiallyEmpty` | Status 200, leeres `history`-Array |
+| `Get_History_AfterChat_ContainsMessages` | Status 200, 2 Einträge (user + assistant) |
+
+### POST /api/reset
+
+| Test | Erwartetes Ergebnis |
+|------|---------------------|
+| `Post_Reset_ClearsHistory` | Status 200, History danach leer |
+
+### POST /api/chat
+
+| Test | Erwartetes Ergebnis |
+|------|---------------------|
+| `Post_Chat_ValidPrompt_Returns200WithResponse` | Status 200, Antwort im JSON |
+| `Post_Chat_EmptyPrompt_Returns400` | Status 400, `error`-Feld im JSON |
+| `Post_Chat_MissingPrompt_Returns400` | Status 400 |
+| `Post_Chat_PassesExecModeToHandler` | `auto-exec` wird korrekt weitergereicht |
+| `Post_Chat_UnknownExecMode_FallsBackToServerDefault` | Unbekannter Mode → Server-Default |
+| `Post_Chat_AllExecModes_AreParsedCorrectly` | ask / dry-run / auto-exec / no-exec korrekt geparst |
+| `Post_Chat_WithCommands_ReturnsCommandsInResponse` | Commands + `usedToolCalls` im Response |
+| `Post_Chat_HandlerThrows_Returns500` | Status 500 mit `error`-Feld (Fehler-Szenario) |
+
+### Fehler-Route
+
+| Test | Erwartetes Ergebnis |
+|------|---------------------|
+| `Get_UnknownRoute_Returns404` | Status 404 |
+
+---
+
+## CI-Integration
+
+Der Workflow `.github/workflows/ci.yml` läuft bei jedem Push auf `main` und bei
+jedem Pull Request gegen `main`. Er führt folgende Schritte aus:
+
+1. Frontend bauen (`npm ci && npm run build`)
+2. .NET Solution bauen (`dotnet build --configuration Release`)
+3. Alle Tests ausführen (`dotnet test`)
+4. TRX-Testergebnis-Artefakt hochladen
+
+**Neue UI-Merges nach `main` sind automatisch an grünen Regressionschecks gekoppelt.**
+
+---
+
+## Architektur der Tests
+
+```
+tests/bashGPT.Tests/
+└── Server/
+    ├── FakePromptHandler.cs   # Stub: konfigurierbare Dummy-Antworten ohne LLM
+    └── ServerHostTests.cs     # Integration-Tests: echter HTTP-Listener, zufälliger Port
+```
+
+### FakePromptHandler
+
+- Implementiert `IPromptHandler`
+- Felder `NextResult`, `NextException` sind pro Test konfigurierbar
+- `LastOptions` und `CallCount` erlauben Assertions auf den übergebenen Optionen
+
+### Testlebenszyklus (IAsyncLifetime)
+
+1. **InitializeAsync**: Freien Port ermitteln → `ServerHost.RunAsync` starten →
+   Warten bis Server bereit
+2. **Test**: HTTP-Anfragen über `HttpClient` an `http://127.0.0.1:{port}`
+3. **DisposeAsync**: CancellationToken canceln → Probe-Anfrage senden (entsperrt
+   `GetContextAsync`) → auf Server-Aufgabe warten (max. 5 s)
+
+---
+
+## Manuelle Regressionsprüfung
+
+Bei größeren Änderungen an der UI oder dem Server-Code kann zusätzlich eine manuelle
+Prüfung sinnvoll sein:
+
+```bash
+# Server starten
+dotnet run --project src/bashGPT -- serve --no-browser
+
+# Im Browser öffnen
+open http://localhost:5050
+
+# Manuell prüfen:
+# 1. v2-UI aktivieren (localStorage: bashgpt_ui_v2=true, Seite neu laden)
+# 2. Dashboard öffnen → Use-Case per Klick ausführen
+# 3. Chat öffnen → Nachricht senden (no-exec), Antwort erscheint
+# 4. Exec-Mode wechseln (ask/dry-run/auto-exec/no-exec), Nachricht senden
+# 5. Terminal-Panel ein-/ausblenden
+# 6. Session neu starten (Neuer Chat)
+# 7. Einstellungen öffnen → Provider/Modell ändern
+# 8. Zur alten UI wechseln (v1), zurück zu v2
+```

--- a/src/bashGPT/Cli/IPromptHandler.cs
+++ b/src/bashGPT/Cli/IPromptHandler.cs
@@ -1,0 +1,6 @@
+namespace BashGPT.Cli;
+
+public interface IPromptHandler
+{
+    Task<ServerChatResult> RunServerChatAsync(ServerChatOptions opts, CancellationToken ct = default);
+}

--- a/src/bashGPT/Cli/PromptHandler.cs
+++ b/src/bashGPT/Cli/PromptHandler.cs
@@ -9,7 +9,7 @@ namespace BashGPT.Cli;
 /// </summary>
 public class PromptHandler(
     ConfigurationService configService,
-    ShellContextCollector contextCollector)
+    ShellContextCollector contextCollector) : IPromptHandler
 {
     public async Task<int> RunAsync(CliOptions opts, CancellationToken ct = default)
     {

--- a/src/bashGPT/Server/ServerHost.cs
+++ b/src/bashGPT/Server/ServerHost.cs
@@ -9,7 +9,7 @@ using BashGPT.Shell;
 
 namespace BashGPT.Server;
 
-public class ServerHost(PromptHandler handler)
+public class ServerHost(IPromptHandler handler)
 {
     private readonly List<ChatMessage> _history = [];
     private readonly object _historyLock = new();

--- a/tests/bashGPT.Tests/Server/FakePromptHandler.cs
+++ b/tests/bashGPT.Tests/Server/FakePromptHandler.cs
@@ -1,0 +1,33 @@
+using BashGPT.Cli;
+using BashGPT.Shell;
+
+namespace BashGPT.Tests.Server;
+
+/// <summary>
+/// Test-Stub für IPromptHandler – gibt konfigurierbare Dummy-Antworten zurück
+/// ohne echte LLM-Aufrufe zu machen.
+/// </summary>
+internal sealed class FakePromptHandler : IPromptHandler
+{
+    public ServerChatResult NextResult { get; set; } = new(
+        Response: "Fake-Antwort vom LLM.",
+        Commands: [],
+        Logs: [],
+        UsedToolCalls: false);
+
+    public Exception? NextException { get; set; }
+
+    public ServerChatOptions? LastOptions { get; private set; }
+    public int CallCount { get; private set; }
+
+    public Task<ServerChatResult> RunServerChatAsync(ServerChatOptions opts, CancellationToken ct = default)
+    {
+        LastOptions = opts;
+        CallCount++;
+
+        if (NextException is not null)
+            throw NextException;
+
+        return Task.FromResult(NextResult);
+    }
+}

--- a/tests/bashGPT.Tests/Server/ServerHostTests.cs
+++ b/tests/bashGPT.Tests/Server/ServerHostTests.cs
@@ -1,0 +1,292 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using BashGPT.Configuration;
+using BashGPT.Server;
+using BashGPT.Shell;
+
+namespace BashGPT.Tests.Server;
+
+/// <summary>
+/// Integration-Tests für ServerHost: starten den echten HTTP-Listener auf einem
+/// zufälligen Port und prüfen alle API-Endpunkte ohne echte LLM-Verbindung.
+/// </summary>
+public sealed class ServerHostTests : IAsyncLifetime
+{
+    private readonly FakePromptHandler _handler = new();
+    private readonly HttpClient _client = new();
+    private ServerHost _server = null!;
+    private CancellationTokenSource _cts = null!;
+    private Task _serverTask = null!;
+    private string _baseUrl = string.Empty;
+
+    // ── Setup / Teardown ────────────────────────────────────────────────────
+
+    public async Task InitializeAsync()
+    {
+        var port = GetFreePort();
+        _baseUrl = $"http://127.0.0.1:{port}";
+        _client.BaseAddress = new Uri(_baseUrl);
+
+        var options = new ServerOptions(
+            Port: port,
+            NoBrowser: true,
+            Provider: null,
+            Model: null,
+            NoContext: true,
+            IncludeDir: false,
+            ExecMode: ExecutionMode.NoExec,
+            Verbose: false,
+            ForceTools: false);
+
+        _server = new ServerHost(_handler);
+        _cts = new CancellationTokenSource();
+        _serverTask = _server.RunAsync(options, _cts.Token);
+
+        // Kurz warten, bis der Listener bereit ist
+        await WaitForServerAsync(_baseUrl);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        // GetContextAsync() ignoriert CancellationToken – wir senden eine letzte
+        // Probe-Anfrage, damit der Listener-Loop die CT-Prüfung erreicht.
+        try
+        {
+            using var probe = new HttpClient();
+            await probe.GetAsync($"{_baseUrl}/").ConfigureAwait(false);
+        }
+        catch { /* ignorieren */ }
+
+        try { await _serverTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch { /* TaskCanceledException oder Timeout erwartet */ }
+
+        _client.Dispose();
+        _cts.Dispose();
+    }
+
+    // ── GET / ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_Root_Returns200WithHtml()
+    {
+        var response = await _client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("text/html", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    // ── GET /bundle.js ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_BundleJs_Returns200WithJavaScript()
+    {
+        var response = await _client.GetAsync("/bundle.js");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("javascript", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    // ── GET /api/history ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_History_InitiallyEmpty()
+    {
+        var json = await _client.GetFromJsonAsync<JsonElement>("/api/history");
+
+        var history = json.GetProperty("history");
+        Assert.Equal(JsonValueKind.Array, history.ValueKind);
+        Assert.Equal(0, history.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Get_History_AfterChat_ContainsMessages()
+    {
+        await PostChatAsync("Hallo Welt");
+
+        var json = await _client.GetFromJsonAsync<JsonElement>("/api/history");
+        var history = json.GetProperty("history");
+
+        Assert.Equal(2, history.GetArrayLength()); // user + assistant
+        Assert.Equal("user", history[0].GetProperty("role").GetString());
+        Assert.Equal("assistant", history[1].GetProperty("role").GetString());
+    }
+
+    // ── POST /api/reset ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_Reset_ClearsHistory()
+    {
+        await PostChatAsync("eine Nachricht");
+        var before = await _client.GetFromJsonAsync<JsonElement>("/api/history");
+        Assert.NotEqual(0, before.GetProperty("history").GetArrayLength());
+
+        var resetResponse = await _client.PostAsync("/api/reset", null);
+        Assert.Equal(HttpStatusCode.OK, resetResponse.StatusCode);
+
+        var after = await _client.GetFromJsonAsync<JsonElement>("/api/history");
+        Assert.Equal(0, after.GetProperty("history").GetArrayLength());
+    }
+
+    // ── POST /api/chat ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_Chat_ValidPrompt_Returns200WithResponse()
+    {
+        _handler.NextResult = new("Das ist eine Test-Antwort.", [], [], false);
+
+        var response = await PostChatAsync("Was ist Zeit?");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Das ist eine Test-Antwort.", json.GetProperty("response").GetString());
+        Assert.False(json.GetProperty("usedToolCalls").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Post_Chat_EmptyPrompt_Returns400()
+    {
+        var response = await SendChatRaw(prompt: "   ");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(json.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public async Task Post_Chat_MissingPrompt_Returns400()
+    {
+        var body = JsonSerializer.Serialize(new { execMode = "no-exec" });
+        var response = await _client.PostAsync("/api/chat",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_Chat_PassesExecModeToHandler()
+    {
+        await SendChatRaw("Test", execMode: "auto-exec");
+
+        Assert.Equal(ExecutionMode.AutoExec, _handler.LastOptions?.ExecMode);
+    }
+
+    [Fact]
+    public async Task Post_Chat_UnknownExecMode_FallsBackToServerDefault()
+    {
+        await SendChatRaw("Test", execMode: "unknown-mode");
+
+        // ServerOptions.ExecMode = NoExec (gesetzt in InitializeAsync)
+        Assert.Equal(ExecutionMode.NoExec, _handler.LastOptions?.ExecMode);
+    }
+
+    [Fact]
+    public async Task Post_Chat_WithCommands_ReturnsCommandsInResponse()
+    {
+        _handler.NextResult = new(
+            Response: "Habe ls ausgeführt.",
+            Commands: [new CommandResult("ls -la", 0, "total 0\ndrwxr-xr-x  2 user user   40 Feb 28 12:00 .", true)],
+            Logs: [],
+            UsedToolCalls: true);
+
+        var response = await PostChatAsync("Liste Dateien auf");
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.True(json.GetProperty("usedToolCalls").GetBoolean());
+
+        var commands = json.GetProperty("commands");
+        Assert.Equal(1, commands.GetArrayLength());
+        Assert.Equal("ls -la", commands[0].GetProperty("command").GetString());
+        Assert.Equal(0, commands[0].GetProperty("exitCode").GetInt32());
+        Assert.True(commands[0].GetProperty("wasExecuted").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Post_Chat_HandlerThrows_Returns500()
+    {
+        _handler.NextException = new InvalidOperationException("Simulierter Fehler");
+
+        var response = await PostChatAsync("Irgendwas");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(json.TryGetProperty("error", out _));
+    }
+
+    // ── Exec-Mode-Wechsel ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("ask", ExecutionMode.Ask)]
+    [InlineData("dry-run", ExecutionMode.DryRun)]
+    [InlineData("auto-exec", ExecutionMode.AutoExec)]
+    [InlineData("no-exec", ExecutionMode.NoExec)]
+    public async Task Post_Chat_AllExecModes_AreParsedCorrectly(string modeString, ExecutionMode expected)
+    {
+        await SendChatRaw("Test", execMode: modeString);
+
+        Assert.Equal(expected, _handler.LastOptions?.ExecMode);
+    }
+
+    // ── 404 ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_UnknownRoute_Returns404()
+    {
+        var response = await _client.GetAsync("/api/not-existing");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ── Hilfsmethoden ────────────────────────────────────────────────────────
+
+    private async Task<HttpResponseMessage> PostChatAsync(string prompt, string execMode = "no-exec")
+    {
+        return await SendChatRaw(prompt, execMode);
+    }
+
+    private async Task<HttpResponseMessage> SendChatRaw(string? prompt = null, string? execMode = null)
+    {
+        var payload = new Dictionary<string, object?>();
+        if (prompt is not null) payload["prompt"] = prompt;
+        if (execMode is not null) payload["execMode"] = execMode;
+
+        var body = JsonSerializer.Serialize(payload);
+        return await _client.PostAsync("/api/chat",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task WaitForServerAsync(string baseUrl, int maxWaitMs = 3000)
+    {
+        using var probe = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        var deadline = DateTime.UtcNow.AddMilliseconds(maxWaitMs);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                await probe.GetAsync("/");
+                return;
+            }
+            catch
+            {
+                await Task.Delay(50);
+            }
+        }
+
+        throw new TimeoutException($"Server auf {baseUrl} nicht erreichbar nach {maxWaitMs} ms.");
+    }
+}


### PR DESCRIPTION
## Summary

- `IPromptHandler`-Interface extrahiert → `PromptHandler` implementiert es → `ServerHost` nimmt Interface statt Konkret-Klasse (minimale Prod-Änderung für Testbarkeit)
- `FakePromptHandler`: konfigurierbarer Stub (`NextResult`, `NextException`, `LastOptions`, `CallCount`) ohne LLM-Verbindung
- **17 neue Integration-Tests** (`ServerHostTests`, xUnit `IAsyncLifetime`): echter HTTP-Listener auf zufälligem Port pro Test
- **GitHub Actions CI** (`.github/workflows/ci.yml`): läuft bei Push/PR auf `main`; Frontend-Build → .NET-Build → alle Tests → TRX-Artefakt
- **Testrunbook** `docs/testing/runbook-server-ui.md`: Runbook mit lokalem Run, Testfall-Tabelle, Architektur und manueller Checkliste

## Abgedeckte Testfälle

| Endpunkt | Szenario | Test |
|---|---|---|
| `GET /` | 200 + HTML | ✅ |
| `GET /bundle.js` | 200 + JS | ✅ |
| `GET /api/history` | Leer initial | ✅ |
| `GET /api/history` | Nach Chat befüllt | ✅ |
| `POST /api/reset` | Löscht History | ✅ |
| `POST /api/chat` | Valider Prompt → 200 | ✅ |
| `POST /api/chat` | Leerer Prompt → 400 | ✅ |
| `POST /api/chat` | Fehlender Prompt → 400 | ✅ |
| `POST /api/chat` | ExecMode-Weiterleitung | ✅ |
| `POST /api/chat` | Unbekannter ExecMode → Fallback | ✅ |
| `POST /api/chat` | Alle 4 ExecModes (Theory) | ✅ |
| `POST /api/chat` | Commands in Response | ✅ |
| `POST /api/chat` | Handler wirft → 500 | ✅ (Fehler-Szenario) |
| Unbekannte Route | 404 | ✅ |

## Test plan

- [ ] `dotnet test` lokal: alle 95 Tests grün
- [ ] CI-Workflow läuft durch auf GitHub Actions

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Hinzufügen einer umfangreichen Testsuite für die Server-API mit Abdeckung von HTTP-Endpoints, Fehlerbehandlung und verschiedener Ausführungsmodi.

* **Chores**
  * Einführung einer automatisierten CI-Pipeline für kontinuierliche Integration und Testausführung.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->