### PR TITLE
test: Issue #10 – ChatAsync & Retry-Tests für Cerebras und Ollama

### DIFF
--- a/tests/bashGPT.Tests/Providers/CerebrasProviderTests.cs
+++ b/tests/bashGPT.Tests/Providers/CerebrasProviderTests.cs
@@ -149,4 +149,127 @@ public class CerebrasProviderTests
         Assert.Equal("Bearer my-secret-key",
             handler.LastRequest?.Headers.Authorization?.ToString());
     }
+
+    // ── ChatAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChatAsync_NonStream_ReturnsTextContent()
+    {
+        var json = """{"choices":[{"message":{"content":"Hallo Welt","tool_calls":null}}]}""";
+        var handler = new TestHttpMessageHandler(json, contentType: "application/json");
+        var provider = new CerebrasProvider(
+            new CerebrasConfig { ApiKey = "key", Model = "test" },
+            new HttpClient(handler));
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "test")], Stream: false));
+
+        Assert.Equal("Hallo Welt", result.Content);
+        Assert.Empty(result.ToolCalls);
+    }
+
+    [Fact]
+    public async Task ChatAsync_NonStream_ReturnsToolCall()
+    {
+        var json = """
+            {"choices":[{"message":{"content":null,"tool_calls":[
+              {"id":"call_1","type":"function","function":{"name":"bash","arguments":"{\"command\":\"ls -la\"}"}}
+            ]}}]}
+            """;
+        var handler = new TestHttpMessageHandler(json, contentType: "application/json");
+        var provider = new CerebrasProvider(
+            new CerebrasConfig { ApiKey = "key", Model = "test" },
+            new HttpClient(handler));
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "liste dateien")],
+                Tools: [ToolDefinitions.Bash], Stream: false));
+
+        Assert.Single(result.ToolCalls);
+        Assert.Equal("bash", result.ToolCalls[0].Name);
+        Assert.Contains("ls -la", result.ToolCalls[0].ArgumentsJson);
+    }
+
+    [Fact]
+    public async Task ChatAsync_Stream_ReturnsTextContent()
+    {
+        var sse = """
+            data: {"choices":[{"delta":{"content":"foo"}}]}
+            data: {"choices":[{"delta":{"content":"bar"}}]}
+            data: [DONE]
+            """;
+        var tokens = new List<string>();
+        var provider = CreateProvider(sse);
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "test")],
+                Stream: true, OnToken: t => tokens.Add(t)));
+
+        Assert.Equal(["foo", "bar"], tokens);
+        Assert.Equal("foobar", result.Content);
+    }
+
+    // ── 429 Retry-Logik ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChatAsync_Retries_On429_ThenSucceeds()
+    {
+        // Retry-After: 0 → kein Warten im Test
+        var successBody = """{"choices":[{"message":{"content":"OK","tool_calls":null}}]}""";
+        var handler = new SequentialHttpMessageHandler(
+            SequentialHttpMessageHandler.TooManyRequests(),
+            SequentialHttpMessageHandler.Ok(successBody));
+
+        var provider = new CerebrasProvider(
+            new CerebrasConfig { ApiKey = "key", Model = "test" },
+            new HttpClient(handler));
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "test")], Stream: false));
+
+        Assert.Equal(2, handler.CallCount);  // einmal 429, einmal 200
+        Assert.Equal("OK", result.Content);
+    }
+
+    [Fact]
+    public async Task ChatAsync_RetriesTwice_ThenSucceeds()
+    {
+        var successBody = """{"choices":[{"message":{"content":"Erfolg","tool_calls":null}}]}""";
+        var handler = new SequentialHttpMessageHandler(
+            SequentialHttpMessageHandler.TooManyRequests(),
+            SequentialHttpMessageHandler.TooManyRequests(),
+            SequentialHttpMessageHandler.Ok(successBody));
+
+        var provider = new CerebrasProvider(
+            new CerebrasConfig { ApiKey = "key", Model = "test" },
+            new HttpClient(handler));
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "test")], Stream: false));
+
+        Assert.Equal(3, handler.CallCount);
+        Assert.Equal("Erfolg", result.Content);
+    }
+
+    [Fact]
+    public async Task ChatAsync_ThrowsAfterMaxRetries()
+    {
+        // 4 × 429 überschreitet das Limit von 3 Retries (= 4 Gesamtversuche)
+        var handler = new SequentialHttpMessageHandler(
+            SequentialHttpMessageHandler.TooManyRequests(),
+            SequentialHttpMessageHandler.TooManyRequests(),
+            SequentialHttpMessageHandler.TooManyRequests(),
+            SequentialHttpMessageHandler.TooManyRequests());
+
+        var provider = new CerebrasProvider(
+            new CerebrasConfig { ApiKey = "key", Model = "test" },
+            new HttpClient(handler));
+
+        var ex = await Assert.ThrowsAsync<LlmProviderException>(async () =>
+            await provider.ChatAsync(
+                new LlmChatRequest([new ChatMessage(ChatRole.User, "test")], Stream: false)));
+
+        Assert.Equal(4, handler.CallCount);
+        Assert.Contains("Rate-Limit", ex.Message);
+    }
 }

--- a/tests/bashGPT.Tests/Providers/OllamaProviderTests.cs
+++ b/tests/bashGPT.Tests/Providers/OllamaProviderTests.cs
@@ -101,4 +101,72 @@ public class OllamaProviderTests
         Assert.Equal("Ollama",      provider.Name);
         Assert.Equal("gpt-oss:20b", provider.Model);
     }
+
+    // ── ChatAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChatAsync_NonStream_ReturnsTextContent()
+    {
+        var json = """{"message":{"role":"assistant","content":"Hallo Welt","tool_calls":null},"done":true}""";
+        var handler = new TestHttpMessageHandler(json, contentType: "application/json");
+        var provider = new OllamaProvider(
+            new OllamaConfig { BaseUrl = "http://localhost:11434", Model = "test" },
+            new HttpClient(handler));
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "test")], Stream: false));
+
+        Assert.Equal("Hallo Welt", result.Content);
+        Assert.Empty(result.ToolCalls);
+    }
+
+    [Fact]
+    public async Task ChatAsync_NonStream_ReturnsToolCall()
+    {
+        var json = """
+            {"message":{"role":"assistant","content":"",
+             "tool_calls":[{"type":"function","function":{"name":"bash","arguments":{"command":"ls -la"}}}]},
+             "done":true}
+            """;
+        var handler = new TestHttpMessageHandler(json, contentType: "application/json");
+        var provider = new OllamaProvider(
+            new OllamaConfig { BaseUrl = "http://localhost:11434", Model = "test" },
+            new HttpClient(handler));
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "liste dateien")],
+                Tools: [ToolDefinitions.Bash], Stream: false));
+
+        Assert.Single(result.ToolCalls);
+        Assert.Equal("bash", result.ToolCalls[0].Name);
+        Assert.Contains("ls -la", result.ToolCalls[0].ArgumentsJson);
+    }
+
+    [Fact]
+    public async Task ChatAsync_Stream_ReturnsTextContent()
+    {
+        var ndjson = """
+            {"message":{"role":"assistant","content":"foo"},"done":false}
+            {"message":{"role":"assistant","content":"bar"},"done":true}
+            """;
+        var tokens = new List<string>();
+        var provider = CreateProvider(ndjson);
+
+        var result = await provider.ChatAsync(
+            new LlmChatRequest([new ChatMessage(ChatRole.User, "test")],
+                Stream: true, OnToken: t => tokens.Add(t)));
+
+        Assert.Equal(["foo", "bar"], tokens);
+        Assert.Equal("foobar", result.Content);
+    }
+
+    [Fact]
+    public async Task ChatAsync_ThrowsLlmProviderException_OnHttpError()
+    {
+        var provider = CreateProvider("Internal Server Error", HttpStatusCode.InternalServerError);
+
+        await Assert.ThrowsAsync<LlmProviderException>(async () =>
+            await provider.ChatAsync(
+                new LlmChatRequest([new ChatMessage(ChatRole.User, "test")], Stream: false)));
+    }
 }

--- a/tests/bashGPT.Tests/Providers/TestHttpMessageHandler.cs
+++ b/tests/bashGPT.Tests/Providers/TestHttpMessageHandler.cs
@@ -3,7 +3,7 @@ using System.Net;
 namespace BashGPT.Tests.Providers;
 
 /// <summary>
-/// Einfacher Mock-Handler für HttpClient-Tests.
+/// Gibt bei jedem Aufruf dieselbe Antwort zurück.
 /// </summary>
 internal sealed class TestHttpMessageHandler(
     string responseBody,
@@ -23,4 +23,49 @@ internal sealed class TestHttpMessageHandler(
         };
         return Task.FromResult(response);
     }
+}
+
+/// <summary>
+/// Gibt eine Sequenz vorgefertigter <see cref="HttpResponseMessage"/>-Objekte zurück.
+/// Nützlich für Retry-Tests: erste Anfrage → 429, zweite → 200 etc.
+/// </summary>
+internal sealed class SequentialHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses;
+    public int CallCount { get; private set; }
+
+    public SequentialHttpMessageHandler(params HttpResponseMessage[] responses)
+    {
+        _responses = new Queue<HttpResponseMessage>(responses);
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        CallCount++;
+        return _responses.TryDequeue(out var response)
+            ? Task.FromResult(response)
+            : throw new InvalidOperationException("Keine weiteren Antworten in der Warteschlange.");
+    }
+
+    /// <summary>Baut eine 429-Antwort mit Retry-After: 0 (kein Warten im Test).</summary>
+    public static HttpResponseMessage TooManyRequests(string body = "{}") =>
+        TooManyRequestsWithRetryAfter(TimeSpan.Zero, body);
+
+    public static HttpResponseMessage TooManyRequestsWithRetryAfter(TimeSpan delay, string body = "{}")
+    {
+        var msg = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+        };
+        msg.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(delay);
+        return msg;
+    }
+
+    /// <summary>Baut eine einfache 200-OK-Antwort.</summary>
+    public static HttpResponseMessage Ok(string body, string contentType = "application/json") =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, contentType)
+        };
 }

--- a/tests/bashGPT.Tests/Server/ServerHostTests.cs
+++ b/tests/bashGPT.Tests/Server/ServerHostTests.cs
@@ -269,7 +269,7 @@ public sealed class ServerHostTests : IAsyncLifetime
         return port;
     }
 
-    private static async Task WaitForServerAsync(string baseUrl, int maxWaitMs = 3000)
+    private static async Task WaitForServerAsync(string baseUrl, int maxWaitMs = 5000)
     {
         using var probe = new HttpClient { BaseAddress = new Uri(baseUrl) };
         var deadline = DateTime.UtcNow.AddMilliseconds(maxWaitMs);


### PR DESCRIPTION
## Summary

- **Cerebras `ChatAsync`**: Tests für non-stream (Text + Tool-Call), stream (OnToken + Content)
- **Cerebras Retry-Logik**: 1× Retry → Erfolg, 2× Retry → Erfolg, 4× 429 → Exception nach MaxRetries
- **Ollama `ChatAsync`**: Tests für non-stream (Text + Tool-Call), stream (OnToken + Content), HTTP-Fehler
- **SequentialHttpMessageHandler**: Neue Test-Infrastruktur für sequenzielle Mock-Antworten
- **ServerHostTests**: `WaitForServerAsync` Timeout von 3 s auf 5 s erhöht (flaky fix)

## Test plan

- [x] `dotnet test` lokal ausgeführt: **108/108 Tests bestanden** (vorher 98)
- [x] Alle neuen Tests sind grün
- [x] Keine bestehenden Tests gebrochen

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Änderungen

* **Tests**
  * Hinzugefügt: Umfassende Tests für Chat-Provider-Funktionalität einschließlich Text-Inhalte, Tool-Aufrufe und Streaming.
  * Hinzugefügt: Wiederholungslogik-Tests für Rate-Limiting-Szenarien.
  * Verbessert: Test-Utility-Klassen für HTTP-Antwort-Simulation.
  * Aktualisiert: Server-Test-Timeout-Konfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->