### PR TITLE
feat(#35): /api/settings-Endpunkte implementieren

### DIFF
--- a/src/bashGPT/Program.cs
+++ b/src/bashGPT/Program.cs
@@ -10,7 +10,7 @@ var handler          = new PromptHandler(configService, contextCollector);
 var historyFile      = Path.Combine(
     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
     ".config", "bashgpt", "history.json");
-var serverHost       = new ServerHost(handler, historyFile);
+var serverHost       = new ServerHost(handler, configService, historyFile);
 
 // ── Optionen ─────────────────────────────────────────────────────────────────
 

--- a/src/bashGPT/Server/ServerHost.cs
+++ b/src/bashGPT/Server/ServerHost.cs
@@ -4,18 +4,27 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using BashGPT.Cli;
+using BashGPT.Configuration;
 using BashGPT.Providers;
 using BashGPT.Shell;
 
 namespace BashGPT.Server;
 
-public class ServerHost(IPromptHandler handler, string? historyFile = null)
+public class ServerHost(
+    IPromptHandler handler,
+    ConfigurationService? configService = null,
+    string? historyFile = null)
 {
     private readonly List<ChatMessage> _history = [];
     private readonly object _historyLock = new();
+    private volatile ExecutionMode _execMode = ExecutionMode.Ask;
+    private volatile bool _forceTools = false;
 
     public async Task<int> RunAsync(ServerOptions options, CancellationToken ct = default)
     {
+        _execMode = options.ExecMode;
+        _forceTools = options.ForceTools;
+
         var prefix = $"http://127.0.0.1:{options.Port}/";
         using var listener = new HttpListener();
         listener.Prefixes.Add(prefix);
@@ -102,6 +111,85 @@ public class ServerHost(IPromptHandler handler, string? historyFile = null)
                 return;
             }
 
+            if (req.HttpMethod == "GET" && path == "/api/settings")
+            {
+                if (configService is null)
+                {
+                    await WriteJsonAsync(ctx.Response, new { error = "Kein ConfigurationService verfügbar." }, statusCode: 503);
+                    return;
+                }
+                var config = await configService.LoadAsync();
+                var activeModel = config.DefaultProvider == ProviderType.Cerebras
+                    ? config.Cerebras.Model
+                    : config.Ollama.Model;
+                await WriteJsonAsync(ctx.Response, new
+                {
+                    provider = config.DefaultProvider.ToString().ToLower(),
+                    model = activeModel,
+                    hasApiKey = config.Cerebras.ApiKey is not null,
+                    ollamaHost = config.Ollama.BaseUrl,
+                    execMode = ExecModeToString(_execMode),
+                    forceTools = _forceTools
+                });
+                return;
+            }
+
+            if (req.HttpMethod == "PUT" && path == "/api/settings")
+            {
+                if (configService is null)
+                {
+                    await WriteJsonAsync(ctx.Response, new { error = "Kein ConfigurationService verfügbar." }, statusCode: 503);
+                    return;
+                }
+                var body = await JsonSerializer.DeserializeAsync<SettingsRequest>(
+                    req.InputStream,
+                    JsonDefaults.Options,
+                    ct);
+                if (body is null)
+                {
+                    await WriteJsonAsync(ctx.Response, new { error = "Ungültiger Request-Body." }, statusCode: 400);
+                    return;
+                }
+                var config = await configService.LoadAsync();
+                var providerType = ParseProviderType(body.Provider);
+                if (providerType is not null) config.DefaultProvider = providerType.Value;
+                if (body.Model is not null)
+                {
+                    if (config.DefaultProvider == ProviderType.Cerebras) config.Cerebras.Model = body.Model;
+                    else config.Ollama.Model = body.Model;
+                }
+                if (!string.IsNullOrEmpty(body.ApiKey)) config.Cerebras.ApiKey = body.ApiKey;
+                if (body.OllamaHost is not null) config.Ollama.BaseUrl = body.OllamaHost;
+                if (body.ExecMode is not null) _execMode = ParseExecMode(body.ExecMode) ?? _execMode;
+                if (body.ForceTools is bool ft) _forceTools = ft;
+                await configService.SaveAsync(config);
+                await WriteJsonAsync(ctx.Response, new { ok = true });
+                return;
+            }
+
+            if (req.HttpMethod == "POST" && path == "/api/settings/test")
+            {
+                if (configService is null)
+                {
+                    await WriteJsonAsync(ctx.Response, new { error = "Kein ConfigurationService verfügbar." }, statusCode: 503);
+                    return;
+                }
+                var config = await configService.LoadAsync();
+                var provider = ProviderFactory.Create(config);
+                var sw = Stopwatch.StartNew();
+                try
+                {
+                    await provider.CompleteAsync([new ChatMessage(ChatRole.User, "Hi")], ct);
+                    sw.Stop();
+                    await WriteJsonAsync(ctx.Response, new { ok = true, latencyMs = (int)sw.ElapsedMilliseconds });
+                }
+                catch (LlmProviderException ex)
+                {
+                    await WriteJsonAsync(ctx.Response, new { ok = false, error = ex.Message });
+                }
+                return;
+            }
+
             if (req.HttpMethod == "POST" && path == "/api/chat")
             {
                 var body = await JsonSerializer.DeserializeAsync<ChatRequest>(
@@ -116,7 +204,7 @@ public class ServerHost(IPromptHandler handler, string? historyFile = null)
                 }
 
                 var historySnapshot = GetHistorySnapshot();
-                var requestedMode = ParseExecMode(body.ExecMode) ?? options.ExecMode;
+                var requestedMode = ParseExecMode(body.ExecMode) ?? _execMode;
                 var chatOpts = new ServerChatOptions(
                     Prompt: body.Prompt.Trim(),
                     History: historySnapshot,
@@ -126,7 +214,7 @@ public class ServerHost(IPromptHandler handler, string? historyFile = null)
                     IncludeDir: options.IncludeDir,
                     ExecMode: requestedMode,
                     Verbose: options.Verbose || body.Verbose == true,
-                    ForceTools: options.ForceTools);
+                    ForceTools: _forceTools);
 
                 var result = await handler.RunServerChatAsync(chatOpts, ct);
 
@@ -224,14 +312,32 @@ public class ServerHost(IPromptHandler handler, string? historyFile = null)
         }
     }
 
+    private static ProviderType? ParseProviderType(string? provider) =>
+        provider?.ToLowerInvariant() switch
+        {
+            "ollama"   => ProviderType.Ollama,
+            "cerebras" => ProviderType.Cerebras,
+            _          => null
+        };
+
+    private static string ExecModeToString(ExecutionMode mode) =>
+        mode switch
+        {
+            ExecutionMode.Ask      => "ask",
+            ExecutionMode.DryRun   => "dry-run",
+            ExecutionMode.AutoExec => "auto-exec",
+            ExecutionMode.NoExec   => "no-exec",
+            _                      => "ask"
+        };
+
     private static ExecutionMode? ParseExecMode(string? mode) =>
         mode?.ToLowerInvariant() switch
         {
-            "ask" => ExecutionMode.Ask,
-            "dry-run" => ExecutionMode.DryRun,
+            "ask"       => ExecutionMode.Ask,
+            "dry-run"   => ExecutionMode.DryRun,
             "auto-exec" => ExecutionMode.AutoExec,
-            "no-exec" => ExecutionMode.NoExec,
-            _ => null
+            "no-exec"   => ExecutionMode.NoExec,
+            _           => null
         };
 
     private static HistoryItem ToHistoryItem(ChatMessage message) =>
@@ -286,6 +392,10 @@ public class ServerHost(IPromptHandler handler, string? historyFile = null)
             // Kein Hard-Fail, UI bleibt über URL erreichbar.
         }
     }
+
+    private sealed record SettingsRequest(
+        string? Provider, string? Model, string? ApiKey,
+        string? OllamaHost, string? ExecMode, bool? ForceTools);
 
     private sealed record ChatRequest(string Prompt, string? ExecMode, bool? Verbose);
     private sealed record HistoryItem(string Role, string Content);

--- a/tests/bashGPT.Tests/Server/ServerHostSettingsTests.cs
+++ b/tests/bashGPT.Tests/Server/ServerHostSettingsTests.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using BashGPT.Configuration;
+using BashGPT.Server;
+using BashGPT.Shell;
+
+namespace BashGPT.Tests.Server;
+
+/// <summary>
+/// Integration-Tests für die /api/settings-Endpunkte des ServerHost.
+/// </summary>
+public sealed class ServerHostSettingsTests : IAsyncLifetime
+{
+    private readonly FakePromptHandler _handler = new();
+    private readonly HttpClient _client = new();
+    private ServerHost _server = null!;
+    private CancellationTokenSource _cts = null!;
+    private Task _serverTask = null!;
+    private string _baseUrl = string.Empty;
+    private string _configFile = string.Empty;
+    private TestConfigurationService _configService = null!;
+
+    public async Task InitializeAsync()
+    {
+        _configFile = Path.Combine(Path.GetTempPath(), $"bashgpt-test-{Guid.NewGuid()}.json");
+        _configService = new TestConfigurationService(_configFile);
+
+        var port = GetFreePort();
+        _baseUrl = $"http://127.0.0.1:{port}";
+        _client.BaseAddress = new Uri(_baseUrl);
+
+        var options = new ServerOptions(
+            Port: port,
+            NoBrowser: true,
+            Provider: null,
+            Model: null,
+            NoContext: true,
+            IncludeDir: false,
+            ExecMode: ExecutionMode.Ask,
+            Verbose: false,
+            ForceTools: false);
+
+        _server = new ServerHost(_handler, _configService);
+        _cts = new CancellationTokenSource();
+        _serverTask = _server.RunAsync(options, _cts.Token);
+
+        await WaitForServerAsync(_baseUrl);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        try
+        {
+            using var probe = new HttpClient();
+            await probe.GetAsync($"{_baseUrl}/").ConfigureAwait(false);
+        }
+        catch { /* ignorieren */ }
+
+        try { await _serverTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch { /* TaskCanceledException oder Timeout erwartet */ }
+
+        _client.Dispose();
+        _cts.Dispose();
+
+        if (File.Exists(_configFile))
+            File.Delete(_configFile);
+    }
+
+    // ── GET /api/settings ohne ConfigService ────────────────────────────────
+
+    [Fact]
+    public async Task Get_Settings_WithoutConfigService_Returns503()
+    {
+        // Eigener Server ohne ConfigService
+        var port = GetFreePort();
+        var serverNoConfig = new ServerHost(_handler);
+        using var cts = new CancellationTokenSource();
+        var options = new ServerOptions(port, true, null, null, true, false, ExecutionMode.Ask, false, false);
+        var task = serverNoConfig.RunAsync(options, cts.Token);
+        var url = $"http://127.0.0.1:{port}";
+        await WaitForServerAsync(url);
+
+        using var client = new HttpClient { BaseAddress = new Uri(url) };
+        var response = await client.GetAsync("/api/settings");
+
+        await cts.CancelAsync();
+        try
+        {
+            using var probe = new HttpClient();
+            await probe.GetAsync($"{url}/");
+        }
+        catch { }
+        try { await task.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+
+    // ── GET /api/settings ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_Settings_Returns200_WithDefaultValues()
+    {
+        var response = await _client.GetAsync("/api/settings");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(json.TryGetProperty("provider", out var provider));
+        Assert.True(json.TryGetProperty("model", out _));
+        Assert.True(json.TryGetProperty("hasApiKey", out _));
+        Assert.True(json.TryGetProperty("ollamaHost", out _));
+        Assert.True(json.TryGetProperty("execMode", out _));
+        Assert.True(json.TryGetProperty("forceTools", out _));
+
+        // Standardprovider ist Ollama
+        Assert.Equal("ollama", provider.GetString());
+    }
+
+    // ── PUT /api/settings ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Put_Settings_UpdatesProvider_And_Persists()
+    {
+        var body = JsonSerializer.Serialize(new { provider = "cerebras", model = "test-model" });
+        var putResponse = await _client.PutAsync("/api/settings",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        // Config-Datei prüfen
+        var config = await _configService.LoadAsync();
+        Assert.Equal(ProviderType.Cerebras, config.DefaultProvider);
+        Assert.Equal("test-model", config.Cerebras.Model);
+    }
+
+    [Fact]
+    public async Task Put_Settings_EmptyApiKey_DoesNotOverwriteExisting()
+    {
+        // Zuerst einen API-Key setzen
+        await _configService.SetAsync("cerebras.apiKey", "geheimer-key");
+
+        // PUT mit leerem apiKey senden
+        var body = JsonSerializer.Serialize(new { apiKey = "" });
+        await _client.PutAsync("/api/settings",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        // Key darf nicht überschrieben worden sein
+        var config = await _configService.LoadAsync();
+        Assert.Equal("geheimer-key", config.Cerebras.ApiKey);
+    }
+
+    [Fact]
+    public async Task Put_Settings_UpdatesExecMode_InMemory()
+    {
+        // ExecMode auf auto-exec setzen
+        var body = JsonSerializer.Serialize(new { execMode = "auto-exec" });
+        var putResponse = await _client.PutAsync("/api/settings",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        // GET prüft, ob der In-Memory-Wert aktualisiert wurde
+        var getResponse = await _client.GetFromJsonAsync<JsonElement>("/api/settings");
+        Assert.Equal("auto-exec", getResponse.GetProperty("execMode").GetString());
+    }
+
+    // ── POST /api/settings/test ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_SettingsTest_Returns200_WithOkOrError()
+    {
+        // Ollama ist in CI möglicherweise nicht verfügbar → HTTP 200 in jedem Fall
+        var response = await _client.PostAsync("/api/settings/test", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(json.TryGetProperty("ok", out var ok));
+
+        if (ok.GetBoolean())
+            Assert.True(json.TryGetProperty("latencyMs", out _));
+        else
+            Assert.True(json.TryGetProperty("error", out _));
+    }
+
+    // ── Hilfsmethoden ────────────────────────────────────────────────────────
+
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task WaitForServerAsync(string baseUrl, int maxWaitMs = 5000)
+    {
+        using var probe = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        var deadline = DateTime.UtcNow.AddMilliseconds(maxWaitMs);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                await probe.GetAsync("/");
+                return;
+            }
+            catch
+            {
+                await Task.Delay(50);
+            }
+        }
+
+        throw new TimeoutException($"Server auf {baseUrl} nicht erreichbar nach {maxWaitMs} ms.");
+    }
+}

--- a/tests/bashGPT.Tests/Server/TestConfigurationService.cs
+++ b/tests/bashGPT.Tests/Server/TestConfigurationService.cs
@@ -1,0 +1,8 @@
+using BashGPT.Configuration;
+
+namespace BashGPT.Tests.Server;
+
+internal sealed class TestConfigurationService(string path) : ConfigurationService
+{
+    protected override string ConfigFile => path;
+}


### PR DESCRIPTION
## Summary

- `GET /api/settings` liefert aktuelle Konfiguration (Provider, Modell, hasApiKey, ollamaHost, execMode, forceTools)
- `PUT /api/settings` aktualisiert Provider/Modell/ApiKey/OllamaHost in `config.json` und execMode/forceTools in-memory (reset on restart)
- `POST /api/settings/test` prüft die LLM-Verbindung und gibt `{ ok, latencyMs }` oder `{ ok: false, error }` zurück

## Architektur-Entscheidungen

- `ConfigurationService` wird als optionaler Parameter an `ServerHost` übergeben — bestehende Tests bleiben unverändert
- `_execMode` / `_forceTools` als `volatile`-Felder in `ServerHost` gespeichert, werden beim Server-Start aus `ServerOptions` initialisiert
- Leerer `apiKey` im PUT-Body überschreibt keinen bestehenden Wert
- Verbindungstest fängt `LlmProviderException` und gibt immer HTTP 200 zurück (auch bei Fehler), damit CI nicht bricht

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `src/bashGPT/Server/ServerHost.cs` | 3 neue Endpunkte, volatile Felder, Hilfsmethoden |
| `src/bashGPT/Program.cs` | `configService` an `ServerHost` weitergereicht |
| `tests/…/TestConfigurationService.cs` | Neu: Subklasse mit konfigurierbarem Pfad |
| `tests/…/ServerHostSettingsTests.cs` | Neu: 6 Integration-Tests |

## Test plan

- [x] `dotnet build --configuration Release` — sauber, 0 Fehler
- [x] `dotnet test --configuration Release` — 114/114 bestanden
- [ ] `bashgpt server` starten → Einstellungen-Seite öffnen, keine 404
- [ ] Provider auf "cerebras" setzen, Speichern → `~/.config/bashgpt/config.json` prüfen
- [ ] "Verbindung testen" → Antwort mit `ok`/`error` erscheint
- [ ] Server neu starten → Einstellungen noch vorhanden

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Neue Funktionen**
  * Konfigurationsmanagement-API hinzugefügt: Abrufen, Aktualisieren und Testen von Einstellungen wie Provider, Modell, API-Schlüssel und Ausführungsmodus.

* **Tests**
  * Umfangreiche Test-Suite für Einstellungs-Endpoints hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->