### PR TITLE
feat(#39): Gesamten Verlauf aus den Einstellungen löschen

### DIFF
--- a/src/bashGPT.Web/src/components/chat-app.ts
+++ b/src/bashGPT.Web/src/components/chat-app.ts
@@ -452,6 +452,16 @@ export class ChatApp extends LitElement {
     })
   }
 
+  private async _onClearHistory() {
+    const chatView = this.shadowRoot?.querySelector('bashgpt-chat-view') as any
+    if (chatView) chatView.beforeSend = undefined
+    if (chatView) await chatView.reset()
+    this._localSessions = []
+    writeLocalSessions(this._localSessions)
+    this._sessions = []
+    this._activeSessionId = null
+  }
+
   private _onChatStarted() {
     this._chatReadOnly = false
     // Synthetische Session hinzufügen, damit der Nutzer über die Sidebar zurücknavigieren kann
@@ -599,7 +609,9 @@ export class ChatApp extends LitElement {
           ` : ''}
 
           ${this._view === 'settings' ? html`
-            <bashgpt-settings-view></bashgpt-settings-view>
+            <bashgpt-settings-view
+              @clear-history=${this._onClearHistory}
+            ></bashgpt-settings-view>
           ` : ''}
 
           <bashgpt-chat-view

--- a/src/bashGPT.Web/src/components/settings-view.ts
+++ b/src/bashGPT.Web/src/components/settings-view.ts
@@ -206,6 +206,11 @@ export class SettingsView extends LitElement {
     }
   }
 
+  private _clearHistory() {
+    if (!confirm('Gesamten Verlauf wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.')) return
+    this.dispatchEvent(new CustomEvent('clear-history', { bubbles: true, composed: true }))
+  }
+
   private _switchToV1() {
     localStorage.removeItem('bashgpt_ui_v2')
     location.reload()
@@ -310,6 +315,16 @@ export class SettingsView extends LitElement {
             />
             <label for="force-tools">Force Tools (Tool-Calling erzwingen)</label>
           </div>
+        </div>
+      </div>
+
+      <div class="section">
+        <div class="section-label">Verlauf</div>
+        <div class="hint">Löscht alle gespeicherten Sessions aus dem Browser-Speicher und setzt die Server-History zurück.</div>
+        <div class="actions" style="margin-top: 12px;">
+          <button class="danger" @click=${this._clearHistory}>
+            Gesamten Verlauf löschen
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #39

## Änderungen

**`settings-view.ts`**
- Neuer Abschnitt „Verlauf" mit Button „Gesamten Verlauf löschen"
- `confirm()`-Dialog vor der Aktion
- Dispatcht `clear-history`-Event (bubbles, composed) → kein direkter API-Aufruf in der Komponente

**`chat-app.ts`**
- `_onClearHistory()`: hängendes `beforeSend` verwerfen → `chatView.reset()` (Server-Reset + Messages leeren) → `_localSessions = []` + `writeLocalSessions([])` + `_sessions = []` + `_activeSessionId = null`
- `@clear-history`-Listener auf `<bashgpt-settings-view>`

## Testplan

- [ ] Einstellungen öffnen → Abschnitt „Verlauf" mit Button sichtbar
- [ ] Button klicken → `confirm()`-Dialog erscheint → Abbrechen → nichts passiert
- [ ] Button klicken → Bestätigen → Sidebar zeigt „Noch keine Sessions", Chat leer
- [ ] `localStorage.getItem('bashgpt_sessions_v2')` → `[]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Möglichkeit zum Löschen des gesamten Chatverlaufs über die Einstellungen mit Bestätigungsaufforderung hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->