### PR TITLE
test(#49): Unit-Tests für PromptHandler

### DIFF
--- a/src/bashGPT/Cli/PromptHandler.cs
+++ b/src/bashGPT/Cli/PromptHandler.cs
@@ -9,7 +9,8 @@ namespace BashGPT.Cli;
 /// </summary>
 public class PromptHandler(
     ConfigurationService configService,
-    ShellContextCollector contextCollector) : IPromptHandler
+    ShellContextCollector contextCollector,
+    ILlmProvider? providerOverride = null) : IPromptHandler
 {
     public async Task<int> RunAsync(CliOptions opts, CancellationToken ct = default)
     {
@@ -126,34 +127,41 @@ public class PromptHandler(
         var totalInputTokens = 0;
         var totalOutputTokens = 0;
 
-        AppConfig config;
-        try
-        {
-            config = await configService.LoadAsync();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return new ServerChatResult(
-                Response: $"Konfigurationsfehler: {ex.Message}",
-                Commands: [],
-                Logs: [],
-                UsedToolCalls: false);
-        }
-
-        ApplyModelOverride(config, opts.Provider, opts.Model);
-
         ILlmProvider provider;
-        try
+        if (providerOverride is not null)
         {
-            provider = ProviderFactory.Create(config, opts.Provider);
+            provider = providerOverride;
         }
-        catch (Exception ex)
+        else
         {
-            return new ServerChatResult(
-                Response: $"Provider-Fehler: {ex.Message}",
-                Commands: [],
-                Logs: [],
-                UsedToolCalls: false);
+            AppConfig config;
+            try
+            {
+                config = await configService.LoadAsync();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return new ServerChatResult(
+                    Response: $"Konfigurationsfehler: {ex.Message}",
+                    Commands: [],
+                    Logs: [],
+                    UsedToolCalls: false);
+            }
+
+            ApplyModelOverride(config, opts.Provider, opts.Model);
+
+            try
+            {
+                provider = ProviderFactory.Create(config, opts.Provider);
+            }
+            catch (Exception ex)
+            {
+                return new ServerChatResult(
+                    Response: $"Provider-Fehler: {ex.Message}",
+                    Commands: [],
+                    Logs: [],
+                    UsedToolCalls: false);
+            }
         }
 
         if (opts.Verbose)

--- a/tests/bashGPT.Tests/Cli/FakeLlmProvider.cs
+++ b/tests/bashGPT.Tests/Cli/FakeLlmProvider.cs
@@ -1,0 +1,45 @@
+using BashGPT.Providers;
+using System.Runtime.CompilerServices;
+
+namespace BashGPT.Tests.Cli;
+
+/// <summary>
+/// Test-Stub für ILlmProvider – gibt konfigurierbare LlmChatResponse-Objekte zurück,
+/// ohne echte LLM-Aufrufe zu machen.
+/// </summary>
+internal sealed class FakeLlmProvider : ILlmProvider
+{
+    private readonly Queue<LlmChatResponse> _queue = new();
+
+    public string Name  => "fake";
+    public string Model => "fake-model";
+
+    public int CallCount { get; private set; }
+    public Exception? NextException { get; set; }
+    public IReadOnlyList<ChatMessage>? LastRequestMessages { get; private set; }
+
+    public void Enqueue(LlmChatResponse response) => _queue.Enqueue(response);
+
+    public Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
+    {
+        LastRequestMessages = request.Messages.ToList();
+        CallCount++;
+
+        if (NextException is not null)
+            throw NextException;
+
+        var response = _queue.Count > 0 ? _queue.Dequeue() : new LlmChatResponse("", []);
+        return Task.FromResult(response);
+    }
+
+    public Task<string> CompleteAsync(IEnumerable<ChatMessage> messages, CancellationToken ct = default)
+        => Task.FromResult("fake");
+
+    public async IAsyncEnumerable<string> StreamAsync(
+        IEnumerable<ChatMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return "fake";
+        await Task.CompletedTask;
+    }
+}

--- a/tests/bashGPT.Tests/Cli/PromptHandlerTests.cs
+++ b/tests/bashGPT.Tests/Cli/PromptHandlerTests.cs
@@ -1,0 +1,284 @@
+using BashGPT.Cli;
+using BashGPT.Configuration;
+using BashGPT.Providers;
+using BashGPT.Shell;
+
+namespace BashGPT.Tests.Cli;
+
+/// <summary>
+/// Unit-Tests für PromptHandler.RunServerChatAsync.
+/// Nutzt FakeLlmProvider (via providerOverride) und NoContext=true, um echte
+/// LLM- und Dateisystem-Aufrufe zu vermeiden.
+/// </summary>
+public sealed class PromptHandlerTests
+{
+    // ── Hilfsmethoden ───────────────────────────────────────────────────────
+
+    private static PromptHandler CreateHandler(FakeLlmProvider provider) =>
+        new(new ConfigurationService(), new ShellContextCollector(), provider);
+
+    private static ServerChatOptions Opts(
+        string prompt = "Hallo",
+        ExecutionMode execMode = ExecutionMode.NoExec,
+        bool verbose = false,
+        bool forceTools = false,
+        IReadOnlyList<ChatMessage>? history = null) =>
+        new(
+            Prompt:     prompt,
+            History:    history ?? [],
+            Provider:   null,
+            Model:      null,
+            NoContext:  true,
+            IncludeDir: false,
+            ExecMode:   execMode,
+            Verbose:    verbose,
+            ForceTools: forceTools);
+
+    private static ToolCall BashCall(string cmd, string id = "tc-1") =>
+        new(id, "bash", $$"""{"command":"{{cmd}}"}""");
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RunServerChatAsync_SimpleText_ReturnsContent()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("Hallo Welt!", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts());
+
+        Assert.Equal("Hallo Welt!", result.Response);
+        Assert.False(result.UsedToolCalls);
+        Assert.Equal(1, provider.CallCount);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_LlmProviderException_ReturnsErrorMessage()
+    {
+        var provider = new FakeLlmProvider();
+        provider.NextException = new LlmProviderException("API-Fehler");
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts());
+
+        Assert.Contains("Fehler:", result.Response);
+        Assert.Contains("API-Fehler", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_OperationCanceled_ReturnsAbortedMessage()
+    {
+        var provider = new FakeLlmProvider();
+        provider.NextException = new OperationCanceledException();
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts());
+
+        Assert.Equal("Abgebrochen.", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_SingleToolCall_UsedToolCallsTrue()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("echo hi")]));
+        provider.Enqueue(new LlmChatResponse("Fertig!", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.True(result.UsedToolCalls);
+        Assert.Equal(2, provider.CallCount);
+        Assert.Equal("Fertig!", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_ThreeToolCallRounds_FourProviderCalls()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("ls", "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("pwd", "tc-2")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("date", "tc-3")]));
+        provider.Enqueue(new LlmChatResponse("Alle Runden erledigt.", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.Equal(4, provider.CallCount);
+        Assert.True(result.UsedToolCalls);
+        Assert.Equal("Alle Runden erledigt.", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_FourConsecutiveToolCalls_ReturnsLoopGuardMessage()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-2")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-3")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-4")]));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.Contains("Tool-Call-Schleife", result.Response);
+        Assert.Equal(4, provider.CallCount);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_LoopGuardWithExistingContent_ReturnsContent()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-2")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-3")]));
+        // 4. Antwort hat Tool-Calls UND Content → Content wird zurückgegeben
+        provider.Enqueue(new LlmChatResponse("Eigene Antwort trotz Tool-Call.", [BashCall("top", "tc-4")]));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.Equal("Eigene Antwort trotz Tool-Call.", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_AskExecMode_CommandsNotExecuted()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("rm -rf /", "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("Erledigt.", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.Ask));
+
+        Assert.True(result.Commands.All(c => !c.WasExecuted));
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_DryRunExecMode_CommandsNotExecuted()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("ls -la", "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("Erledigt.", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.True(result.Commands.All(c => !c.WasExecuted));
+        Assert.NotEmpty(result.Commands);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_NoExecMode_FallbackCommandsNotCollected()
+    {
+        // Text-Antwort mit Bash-Block → NoExec überspringt Ausführung
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("```bash\nls\n```", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.NoExec));
+
+        Assert.Empty(result.Commands);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_SingleRound_TokenUsageAccumulated()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("Antwort", [], new TokenUsage(10, 5)));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts());
+
+        Assert.NotNull(result.Usage);
+        Assert.Equal(10, result.Usage!.InputTokens);
+        Assert.Equal(5,  result.Usage.OutputTokens);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_MultiRound_TokenUsageAccumulated()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("ls", "tc-1")], new TokenUsage(10, 5)));
+        provider.Enqueue(new LlmChatResponse("Fertig.", [], new TokenUsage(20, 8)));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.NotNull(result.Usage);
+        Assert.Equal(30, result.Usage!.InputTokens);
+        Assert.Equal(13, result.Usage.OutputTokens);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_NoTokenUsage_UsageIsNull()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("Antwort", []));  // Usage == null
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts());
+
+        Assert.Null(result.Usage);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_MalformedJsonToolCall_CompletesWithoutException()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [new ToolCall("tc-1", "bash", "nicht-json")]));
+        provider.Enqueue(new LlmChatResponse("Fehler ignoriert.", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.Equal("Fehler ignoriert.", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_UnknownToolName_CompletesWithoutException()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [new ToolCall("tc-1", "unbekannt", """{"command":"ls"}""")]));
+        provider.Enqueue(new LlmChatResponse("Unbekanntes Tool ignoriert.", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.Equal("Unbekanntes Tool ignoriert.", result.Response);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_Verbose_LogsContainProviderInfo()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("Ok.", []));
+        var sut = CreateHandler(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(verbose: true));
+
+        Assert.Contains(result.Logs, l => l.Contains("fake") && l.Contains("fake-model"));
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_History_ForwardedToProvider()
+    {
+        var history = new List<ChatMessage>
+        {
+            new(ChatRole.User,      "Frühere Frage"),
+            new(ChatRole.Assistant, "Frühere Antwort"),
+        };
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("Antwort.", []));
+        var sut = CreateHandler(provider);
+
+        await sut.RunServerChatAsync(Opts(history: history));
+
+        Assert.NotNull(provider.LastRequestMessages);
+        Assert.Contains(provider.LastRequestMessages!, m =>
+            m.Role == ChatRole.User && m.Content == "Frühere Frage");
+        Assert.Contains(provider.LastRequestMessages!, m =>
+            m.Role == ChatRole.Assistant && m.Content == "Frühere Antwort");
+    }
+}


### PR DESCRIPTION
Closes #49

## Summary

- `PromptHandler` um optionalen `providerOverride`-Parameter erweitert, damit Tests ohne echte Config oder LLM-Verbindung auskommen
- `FakeLlmProvider`: Queue-basierter `ILlmProvider`-Stub mit `Enqueue()`, `CallCount`, `NextException` und `LastRequestMessages`
- 17 neue Unit-Tests für `RunServerChatAsync`:
  - Einfache Textantwort
  - `LlmProviderException` → Fehler-Response
  - `OperationCanceledException` → "Abgebrochen."
  - Einzelner Tool-Call → `UsedToolCalls == true`
  - 3 Tool-Call-Runden → 4 Provider-Aufrufe
  - 4 aufeinanderfolgende Tool-Calls → Schleifenwächter-Meldung
  - Schleifenwächter mit vorhandenem Content → Content wird zurückgegeben
  - `Ask`-ExecMode → Befehle nicht ausgeführt
  - `DryRun`-ExecMode → Befehle nicht ausgeführt
  - `NoExec`-ExecMode → leere Befehlsliste
  - Token-Akkumulation (1 Runde, mehrere Runden, kein Usage → null)
  - Fehlerhaftes JSON im Tool-Call → kein Absturz
  - Unbekannter Tool-Name → kein Absturz
  - Verbose-Logs enthalten Provider-Info
  - History wird korrekt an Provider weitergeleitet

## Test plan

- [x] `dotnet build` → 0 Fehler, 0 Warnungen
- [x] `dotnet test` → 145 Tests bestanden (vorher 128)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Umfassende Test-Suite für die Prompt-Verarbeitung hinzugefügt, die Zuverlässigkeit und Stabilität verbessert.

* **Verbesserungen**
  * Flexible Provider-Injection ermöglicht verbesserte Testbarkeit und Wartbarkeit des Systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->