### PR TITLE
refactor(#51): BaseLlmProvider – Provider-Duplikation reduzieren

### DIFF
--- a/src/bashGPT/Providers/BaseLlmProvider.cs
+++ b/src/bashGPT/Providers/BaseLlmProvider.cs
@@ -1,0 +1,45 @@
+namespace BashGPT.Providers;
+
+/// <summary>
+/// Gemeinsame Basisfunktionalität für LLM-Provider:
+/// HTTP-Client-Erstellung, Exception-Wrapping und CompleteAsync.
+/// </summary>
+public abstract class BaseLlmProvider(HttpClient? httpClient = null) : ILlmProvider
+{
+    protected readonly HttpClient Http = httpClient ?? CreateDefaultHttpClient();
+
+    public abstract string Name  { get; }
+    public abstract string Model { get; }
+
+    public abstract Task<LlmChatResponse> ChatAsync(
+        LlmChatRequest request,
+        CancellationToken ct = default);
+
+    public abstract IAsyncEnumerable<string> StreamAsync(
+        IEnumerable<ChatMessage> messages,
+        CancellationToken ct = default);
+
+    public async Task<string> CompleteAsync(
+        IEnumerable<ChatMessage> messages,
+        CancellationToken ct = default)
+    {
+        var sb = new System.Text.StringBuilder();
+        await foreach (var token in StreamAsync(messages, ct))
+            sb.Append(token);
+        return sb.ToString();
+    }
+
+    protected static HttpClient CreateDefaultHttpClient()
+    {
+        var handler = new SocketsHttpHandler { UseCookies = false };
+        return new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(5) };
+    }
+
+    protected static LlmProviderException WrapHttpException(
+        HttpRequestException ex, string baseUrl)
+        => new($"Nicht erreichbar ({baseUrl}): {ex.Message}", ex);
+
+    protected static LlmProviderException WrapTimeoutException(
+        TaskCanceledException ex, string context)
+        => new($"Timeout beim Verbinden mit {context}.", ex);
+}

--- a/src/bashGPT/Providers/CerebrasProvider.cs
+++ b/src/bashGPT/Providers/CerebrasProvider.cs
@@ -7,27 +7,13 @@ using BashGPT.Configuration;
 
 namespace BashGPT.Providers;
 
-public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = null) : ILlmProvider
+public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = null)
+    : BaseLlmProvider(httpClient)
 {
-    private readonly HttpClient _http = httpClient ?? CreateHttpClient();
+    public override string Name  => "Cerebras";
+    public override string Model => config.Model;
 
-    public string Name  => "Cerebras";
-    public string Model => config.Model;
-
-    private static HttpClient CreateHttpClient()
-    {
-        var handler = new SocketsHttpHandler
-        {
-            UseCookies = false
-        };
-
-        return new HttpClient(handler)
-        {
-            Timeout = TimeSpan.FromMinutes(5)
-        };
-    }
-
-    public async Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
+    public override async Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
         => await ChatAsyncInternal(request, ct, allowToolChoiceFallback: true);
 
     private async Task<LlmChatResponse> ChatAsyncInternal(
@@ -77,17 +63,16 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
 
             try
             {
-                response = await _http.SendAsync(httpRequest,
+                response = await Http.SendAsync(httpRequest,
                     HttpCompletionOption.ResponseHeadersRead, ct);
             }
             catch (HttpRequestException ex)
             {
-                throw new LlmProviderException(
-                    $"Cerebras API nicht erreichbar ({config.BaseUrl}): {ex.Message}", ex);
+                throw WrapHttpException(ex, config.BaseUrl);
             }
             catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
             {
-                throw new LlmProviderException("Timeout beim Verbinden mit Cerebras API.", ex);
+                throw WrapTimeoutException(ex, "Cerebras API");
             }
 
             if (response.IsSuccessStatusCode)
@@ -204,15 +189,7 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
         return new LlmChatResponse(contentBuilder.ToString(), toolCallsFinal, usage);
     }
 
-    public async Task<string> CompleteAsync(IEnumerable<ChatMessage> messages, CancellationToken ct = default)
-    {
-        var sb = new StringBuilder();
-        await foreach (var token in StreamAsync(messages, ct))
-            sb.Append(token);
-        return sb.ToString();
-    }
-
-    public async IAsyncEnumerable<string> StreamAsync(
+    public override async IAsyncEnumerable<string> StreamAsync(
         IEnumerable<ChatMessage> messages,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -242,17 +219,16 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
         HttpResponseMessage response;
         try
         {
-            response = await _http.SendAsync(httpRequest,
+            response = await Http.SendAsync(httpRequest,
                 HttpCompletionOption.ResponseHeadersRead, ct);
         }
         catch (HttpRequestException ex)
         {
-            throw new LlmProviderException(
-                $"Cerebras API nicht erreichbar ({config.BaseUrl}): {ex.Message}", ex);
+            throw WrapHttpException(ex, config.BaseUrl);
         }
         catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
-            throw new LlmProviderException("Timeout beim Verbinden mit Cerebras API.", ex);
+            throw WrapTimeoutException(ex, "Cerebras API");
         }
 
         if (!response.IsSuccessStatusCode)

--- a/src/bashGPT/Providers/OllamaProvider.cs
+++ b/src/bashGPT/Providers/OllamaProvider.cs
@@ -6,27 +6,13 @@ using BashGPT.Configuration;
 
 namespace BashGPT.Providers;
 
-public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) : ILlmProvider
+public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null)
+    : BaseLlmProvider(httpClient)
 {
-    private readonly HttpClient _http = httpClient ?? CreateHttpClient();
+    public override string Name  => "Ollama";
+    public override string Model => config.Model;
 
-    public string Name  => "Ollama";
-    public string Model => config.Model;
-
-    private static HttpClient CreateHttpClient()
-    {
-        var handler = new SocketsHttpHandler
-        {
-            UseCookies = false
-        };
-
-        return new HttpClient(handler)
-        {
-            Timeout = TimeSpan.FromMinutes(5)
-        };
-    }
-
-    public async Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
+    public override async Task<LlmChatResponse> ChatAsync(LlmChatRequest request, CancellationToken ct = default)
     {
         var ollamaRequest = new OllamaChatRequest
         {
@@ -41,19 +27,16 @@ public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) 
         HttpResponseMessage response;
         try
         {
-            response = await _http.PostAsJsonAsync(
+            response = await Http.PostAsJsonAsync(
                 $"{config.BaseUrl.TrimEnd('/')}/api/chat", ollamaRequest, ct);
         }
         catch (HttpRequestException ex)
         {
-            throw new LlmProviderException(
-                $"Ollama ist nicht erreichbar unter '{config.BaseUrl}'. " +
-                $"Läuft 'ollama serve'? (Details: {ex.Message})", ex);
+            throw WrapHttpException(ex, config.BaseUrl);
         }
         catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
-            throw new LlmProviderException(
-                $"Timeout beim Verbinden mit Ollama ({config.BaseUrl}).", ex);
+            throw WrapTimeoutException(ex, $"Ollama ({config.BaseUrl})");
         }
 
         if (!response.IsSuccessStatusCode)
@@ -142,15 +125,7 @@ public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) 
         return new LlmChatResponse(contentBuilder.ToString(), ordered, usage);
     }
 
-    public async Task<string> CompleteAsync(IEnumerable<ChatMessage> messages, CancellationToken ct = default)
-    {
-        var sb = new System.Text.StringBuilder();
-        await foreach (var token in StreamAsync(messages, ct))
-            sb.Append(token);
-        return sb.ToString();
-    }
-
-    public async IAsyncEnumerable<string> StreamAsync(
+    public override async IAsyncEnumerable<string> StreamAsync(
         IEnumerable<ChatMessage> messages,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -164,19 +139,16 @@ public class OllamaProvider(OllamaConfig config, HttpClient? httpClient = null) 
         HttpResponseMessage response;
         try
         {
-            response = await _http.PostAsJsonAsync(
+            response = await Http.PostAsJsonAsync(
                 $"{config.BaseUrl.TrimEnd('/')}/api/chat", request, ct);
         }
         catch (HttpRequestException ex)
         {
-            throw new LlmProviderException(
-                $"Ollama ist nicht erreichbar unter '{config.BaseUrl}'. " +
-                $"Läuft 'ollama serve'? (Details: {ex.Message})", ex);
+            throw WrapHttpException(ex, config.BaseUrl);
         }
         catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
-            throw new LlmProviderException(
-                $"Timeout beim Verbinden mit Ollama ({config.BaseUrl}).", ex);
+            throw WrapTimeoutException(ex, $"Ollama ({config.BaseUrl})");
         }
 
         if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
Closes #51

## Summary

- Neue abstrakte Klasse `BaseLlmProvider` eingeführt:
  - `CreateDefaultHttpClient()` – ersetzt identische `CreateHttpClient()`-Methoden in beiden Providern
  - `WrapHttpException()` / `WrapTimeoutException()` – zentralisieren das HTTP-Exception-Handling
  - `CompleteAsync()` – identische Implementierung aus beiden Providern hochgezogen
- `CerebrasProvider` und `OllamaProvider` erben von `BaseLlmProvider`:
  - `private readonly HttpClient _http` → `protected readonly HttpClient Http` (aus Basis)
  - `CreateHttpClient()` jeweils entfernt
  - `CompleteAsync()` jeweils entfernt
  - Catch-Blöcke nutzen `WrapHttpException` / `WrapTimeoutException`

## Test plan

- [x] `dotnet build` → 0 Fehler, 0 Warnungen
- [x] `dotnet test` → 145 Tests bestanden
- [x] `CreateHttpClient()` existiert nur noch einmal (in `BaseLlmProvider`)
- [x] HTTP-Exception-Wrapping ist zentralisiert
- [x] Beide Provider erben von `BaseLlmProvider`