### PR TITLE
refactor(#53): LegacyHistory-Datei-I/O entfernen – eine Persistenzstrategie

### DIFF
--- a/src/bashGPT/Program.cs
+++ b/src/bashGPT/Program.cs
@@ -14,7 +14,7 @@ var handler          = new PromptHandler(configService, contextCollector);
 var historyFile      = Path.Combine(configDir, "history.json");
 var sessionsFile     = Path.Combine(configDir, "sessions.json");
 var sessionStore     = new SessionStore(sessionsFile, legacyHistoryFile: historyFile);
-var serverHost       = new ServerHost(handler, configService, historyFile, sessionStore);
+var serverHost       = new ServerHost(handler, configService, sessionStore);
 
 // ── Optionen ─────────────────────────────────────────────────────────────────
 

--- a/src/bashGPT/Server/ChatApiHandler.cs
+++ b/src/bashGPT/Server/ChatApiHandler.cs
@@ -107,10 +107,9 @@ internal sealed class ChatApiHandler(
         }
         else
         {
-            // Fallback: globale In-Memory-History (legacy)
+            // Fallback: globale In-Memory-History (legacy, kein SessionStore)
             legacyHistory.Append(new ChatMessage(ChatRole.User,      body.Prompt.Trim()));
             legacyHistory.Append(new ChatMessage(ChatRole.Assistant, result.Response));
-            await legacyHistory.PersistAsync();
         }
 
         await ApiResponse.WriteJsonAsync(ctx.Response, new

--- a/src/bashGPT/Server/LegacyHistory.cs
+++ b/src/bashGPT/Server/LegacyHistory.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using BashGPT.Providers;
 
 namespace BashGPT.Server;
@@ -6,65 +5,13 @@ namespace BashGPT.Server;
 internal sealed record HistoryItem(string Role, string Content);
 
 /// <summary>
-/// Verwaltet den globalen In-Memory-Gesprächsverlauf und dessen optionale Datei-Persistenz.
+/// Verwaltet den globalen In-Memory-Gesprächsverlauf.
 /// Wird als Fallback genutzt, wenn kein SessionStore verfügbar ist.
 /// </summary>
-internal sealed class LegacyHistory(string? filePath = null)
+internal sealed class LegacyHistory
 {
     private readonly List<ChatMessage> _history = [];
     private readonly object _lock = new();
-
-    public async Task LoadFromFileAsync()
-    {
-        if (filePath is null || !File.Exists(filePath)) return;
-        try
-        {
-            var json = await File.ReadAllTextAsync(filePath);
-            var items = JsonSerializer.Deserialize<List<HistoryItem>>(json, JsonDefaults.Options) ?? [];
-            var messages = items
-                .Select(item => item.Role switch
-                {
-                    "user"      => new ChatMessage(ChatRole.User,      item.Content),
-                    "assistant" => new ChatMessage(ChatRole.Assistant,  item.Content),
-                    _           => (ChatMessage?)null
-                })
-                .Where(m => m is not null)
-                .Select(m => m!)
-                .ToList();
-            lock (_lock)
-            {
-                _history.Clear();
-                _history.AddRange(messages);
-                if (_history.Count > 40)
-                    _history.RemoveRange(0, _history.Count - 40);
-            }
-        }
-        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
-        {
-            // Beschädigte Datei ignorieren – Neustart mit leerem Verlauf
-            _ = ex;
-        }
-    }
-
-    public async Task PersistAsync()
-    {
-        if (filePath is null) return;
-        try
-        {
-            List<HistoryItem> items;
-            lock (_lock)
-                items = _history.Select(m => new HistoryItem(m.RoleString, m.Content)).ToList();
-            var dir = Path.GetDirectoryName(filePath)!;
-            Directory.CreateDirectory(dir);
-            var serialized = JsonSerializer.Serialize(items, JsonDefaults.Options);
-            await File.WriteAllTextAsync(filePath, serialized);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            // Schreibfehler ignorieren
-            _ = ex;
-        }
-    }
 
     public IReadOnlyList<HistoryItem> GetItems()
     {

--- a/src/bashGPT/Server/ServerHost.cs
+++ b/src/bashGPT/Server/ServerHost.cs
@@ -18,11 +18,10 @@ public class ServerHost
     public ServerHost(
         IPromptHandler handler,
         ConfigurationService? configService = null,
-        string? historyFile = null,
         SessionStore? sessionStore = null)
     {
         _state           = new ServerState();
-        _legacyHistory   = new LegacyHistory(historyFile);
+        _legacyHistory   = new LegacyHistory();
         _contextHandler  = new ContextApiHandler();
         _settingsHandler = new SettingsApiHandler(configService, _state);
         _chatHandler     = new ChatApiHandler(handler, _state, _legacyHistory, sessionStore);
@@ -50,8 +49,6 @@ public class ServerHost
 
         Console.WriteLine($"bashGPT Server läuft auf {prefix}");
         Console.WriteLine("Beenden mit Ctrl+C");
-
-        await _legacyHistory.LoadFromFileAsync();
 
         if (!options.NoBrowser)
             TryOpenBrowser(prefix);
@@ -94,13 +91,14 @@ public class ServerHost
             if (req.HttpMethod == "GET"  && path == "/bundle.js")
             { await ApiResponse.WriteResourceAsync(ctx.Response, "bashGPT.Web.bundle.js", "application/javascript; charset=utf-8"); return; }
 
+            // @deprecated – Nur noch für Frontend-Kompatibilität; neue Clients nutzen /api/sessions
             if (req.HttpMethod == "GET"  && path == "/api/history")
             { await ApiResponse.WriteJsonAsync(ctx.Response, new { history = _legacyHistory.GetItems() }); return; }
 
+            // @deprecated – Nur noch für Frontend-Kompatibilität; neue Clients nutzen /api/sessions/clear
             if (req.HttpMethod == "POST" && path == "/api/reset")
             {
                 _legacyHistory.Clear();
-                await _legacyHistory.PersistAsync();
                 await ApiResponse.WriteJsonAsync(ctx.Response, new { ok = true });
                 return;
             }

--- a/src/bashGPT/Server/SessionApiHandler.cs
+++ b/src/bashGPT/Server/SessionApiHandler.cs
@@ -55,7 +55,6 @@ internal sealed class SessionApiHandler(SessionStore? sessionStore, LegacyHistor
         {
             await sessionStore.ClearAsync();
             legacyHistory.Clear();
-            await legacyHistory.PersistAsync();
             await ApiResponse.WriteJsonAsync(ctx.Response, new { ok = true });
             return;
         }


### PR DESCRIPTION
## Summary

- **`LegacyHistory`**: `LoadFromFileAsync()`, `PersistAsync()` und `filePath`-Parameter entfernt – rein In-Memory
- **`ServerHost`**: `historyFile`-Parameter und `LoadFromFileAsync()`-Aufruf entfernt; `PersistAsync()` aus `/api/reset` entfernt; beide Legacy-Endpunkte als `@deprecated` kommentiert
- **`ChatApiHandler`**: `PersistAsync()` aus dem Legacy-Fallback-Pfad entfernt
- **`SessionApiHandler`**: `PersistAsync()` aus `/api/sessions/clear` entfernt; `Clear()` bleibt (bereinigt In-Memory-Zustand)
- **`Program.cs`**: `historyFile` wird nicht mehr an `ServerHost` übergeben (bleibt für `SessionStore.MigrateFromHistoryAsync`)

Einzige Persistenzstrategie ist nun `SessionStore` → `~/.config/bashgpt/sessions.json`.

## Test plan

- [x] `dotnet build` – 0 Fehler
- [x] `dotnet test` – 145/145 Tests grün

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Der Verwaltungsmechanismus für den Gesprächsverlauf wurde vereinfacht. Der Legacy-Gesprächsverlauf wird nun nicht mehr auf der Festplatte gespeichert und wird zwischen Sitzungen gelöscht.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->