### PR TITLE
refactor(#54): Magic Numbers/Strings durch benannte Konstanten ersetzen

### DIFF
--- a/src/bashGPT.Web/src/api.ts
+++ b/src/bashGPT.Web/src/api.ts
@@ -1,6 +1,5 @@
 import type { ChatResponse, ExecMode, FullShellContext, HistoryMessage, Session, Settings } from './types'
-
-const CHAT_TIMEOUT_MS = 120_000
+import { CHAT_TIMEOUT_MS } from './constants'
 
 async function readErrorMessage(res: Response): Promise<string> {
   try {

--- a/src/bashGPT.Web/src/components/chat-app.ts
+++ b/src/bashGPT.Web/src/components/chat-app.ts
@@ -7,6 +7,7 @@ import './chat-view'
 import './terminal-panel'
 import { loadHistory, resetHistory, getSessions, getSession, putSession, deleteSession, clearSessions, createSession } from '../api'
 import type { AppView, Session, ShellContext } from '../types'
+import { SESSION_ID_PREFIX } from '../constants'
 import {
   LIVE_SESSION_ID,
   createLiveSession,
@@ -273,7 +274,7 @@ export class ChatApp extends LitElement {
     if (this._useLocalSessionsFallback && chatView) {
       const snapshot = chatView.getSnapshot?.() as SnapshotMessage[] | undefined
       if (snapshot && snapshot.length > 0 && this._activeSessionId === LIVE_SESSION_ID) {
-        const archivedId = `s-${Date.now()}`
+        const archivedId = `${SESSION_ID_PREFIX}${Date.now()}`
         // ShellContext der Live-Session beim Archivieren mitübernehmen
         const liveShellContext = this._localSessions.find(s => s.id === LIVE_SESSION_ID)?.shellContext
         this._localSessions = upsertSession(this._localSessions, archivedId, snapshot, liveShellContext)
@@ -362,7 +363,7 @@ export class ChatApp extends LitElement {
     const existingLive = this._localSessions.find(s => s.id === LIVE_SESSION_ID)
     let sessions = this._localSessions.filter(s => s.id !== LIVE_SESSION_ID)
     if (existingLive && existingLive.messages.length > 0) {
-      sessions = [...sessions, { ...existingLive, id: `s-${Date.now()}`, isLive: false }]
+      sessions = [...sessions, { ...existingLive, id: `${SESSION_ID_PREFIX}${Date.now()}`, isLive: false }]
     }
 
     // Archivierten Eintrag zur Live-Session promoten und an die Spitze sortieren.

--- a/src/bashGPT.Web/src/constants.ts
+++ b/src/bashGPT.Web/src/constants.ts
@@ -1,0 +1,5 @@
+/** Timeout für /api/chat-Anfragen in Millisekunden. */
+export const CHAT_TIMEOUT_MS = 120_000
+
+/** Präfix für automatisch generierte Session-IDs (muss mit AppDefaults.SessionIdPrefix übereinstimmen). */
+export const SESSION_ID_PREFIX = 's-'

--- a/src/bashGPT/AppDefaults.cs
+++ b/src/bashGPT/AppDefaults.cs
@@ -1,0 +1,25 @@
+namespace BashGPT;
+
+/// <summary>
+/// Zentrale Sammlung aller applikationsweiten Standardwerte und Magic Numbers.
+/// </summary>
+public static class AppDefaults
+{
+    /// <summary>Maximale Tool-Call-Runden pro LLM-Anfrage in PromptHandler.</summary>
+    public const int MaxToolCallRounds = 3;
+
+    /// <summary>Timeout pro Shell-Befehl in Sekunden (CommandExecutor).</summary>
+    public const int CommandTimeoutSeconds = 30;
+
+    /// <summary>Maximale Ausgabe-Zeichen pro Shell-Befehl (CommandExecutor).</summary>
+    public const int MaxCommandOutputChars = 10_000;
+
+    /// <summary>Maximale Anzahl beibehaltener Nachrichten im In-Memory-Verlauf (LegacyHistory).</summary>
+    public const int MaxHistoryMessages = 40;
+
+    /// <summary>Maximale Anzahl HTTP-Wiederholungen bei 429-Fehlern (CerebrasProvider).</summary>
+    public const int MaxProviderRetries = 3;
+
+    /// <summary>Präfix für automatisch generierte Session-IDs.</summary>
+    public const string SessionIdPrefix = "s-";
+}

--- a/src/bashGPT/Cli/PromptHandler.cs
+++ b/src/bashGPT/Cli/PromptHandler.cs
@@ -1,6 +1,7 @@
 using BashGPT.Configuration;
 using BashGPT.Providers;
 using BashGPT.Shell;
+using BashGPT;
 
 namespace BashGPT.Cli;
 
@@ -203,9 +204,8 @@ public class PromptHandler(
             if (opts.Verbose)
                 logs.Add($"Tool-Calls empfangen: {currentResponse.ToolCalls.Count}");
 
-            const int maxToolRounds = 3;
             var rounds = 0;
-            while (currentResponse.ToolCalls.Count > 0 && rounds < maxToolRounds)
+            while (currentResponse.ToolCalls.Count > 0 && rounds < AppDefaults.MaxToolCallRounds)
             {
                 rounds++;
                 var toolCalls = currentResponse.ToolCalls;
@@ -255,7 +255,7 @@ public class PromptHandler(
                     "Tool-Call-Schleife erkannt und beendet. " +
                     "Bitte nutze nicht-interaktive Befehle (z. B. 'ps aux --sort=-%cpu | head' statt 'top').";
                 if (opts.Verbose)
-                    logs.Add($"Maximale Tool-Call-Runden erreicht ({maxToolRounds}).");
+                    logs.Add($"Maximale Tool-Call-Runden erreicht ({AppDefaults.MaxToolCallRounds}).");
                 var responseText = string.IsNullOrWhiteSpace(currentResponse.Content)
                     ? loopGuardMessage
                     : currentResponse.Content;

--- a/src/bashGPT/Providers/CerebrasProvider.cs
+++ b/src/bashGPT/Providers/CerebrasProvider.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using BashGPT.Configuration;
+using BashGPT;
 
 namespace BashGPT.Providers;
 
@@ -49,10 +50,9 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
         var serialized = JsonSerializer.Serialize(openAiRequest, JsonDefaults.Options);
         var url = $"{config.BaseUrl.TrimEnd('/')}/chat/completions";
 
-        const int maxRetries = 3;
         HttpResponseMessage response = null!;
 
-        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        for (var attempt = 0; attempt <= AppDefaults.MaxProviderRetries; attempt++)
         {
             using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
             {
@@ -91,7 +91,7 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
             }
 
             // Bei 429 automatisch wiederholen (bis maxRetries erschöpft sind)
-            if ((int)response.StatusCode == 429 && attempt < maxRetries)
+            if ((int)response.StatusCode == 429 && attempt < AppDefaults.MaxProviderRetries)
             {
                 var delay = GetRetryDelay(response, attempt);
                 await Task.Delay(delay, ct);
@@ -101,7 +101,7 @@ public class CerebrasProvider(CerebrasConfig config, HttpClient? httpClient = nu
             var hint = (int)response.StatusCode switch
             {
                 401 => " → API-Key ungültig oder abgelaufen.",
-                429 => $" → Rate-Limit nach {maxRetries} Versuchen weiterhin aktiv.",
+                429 => $" → Rate-Limit nach {AppDefaults.MaxProviderRetries} Versuchen weiterhin aktiv.",
                 _   => ""
             };
             throw new LlmProviderException(

--- a/src/bashGPT/Server/LegacyHistory.cs
+++ b/src/bashGPT/Server/LegacyHistory.cs
@@ -1,4 +1,5 @@
 using BashGPT.Providers;
+using BashGPT;
 
 namespace BashGPT.Server;
 
@@ -30,8 +31,8 @@ internal sealed class LegacyHistory
         lock (_lock)
         {
             _history.Add(message);
-            if (_history.Count > 40)
-                _history.RemoveRange(0, _history.Count - 40);
+            if (_history.Count > AppDefaults.MaxHistoryMessages)
+                _history.RemoveRange(0, _history.Count - AppDefaults.MaxHistoryMessages);
         }
     }
 

--- a/src/bashGPT/Server/SessionApiHandler.cs
+++ b/src/bashGPT/Server/SessionApiHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json;
 using BashGPT.Providers;
 using BashGPT.Storage;
+using BashGPT;
 
 namespace BashGPT.Server;
 
@@ -37,7 +38,7 @@ internal sealed class SessionApiHandler(SessionStore? sessionStore, LegacyHistor
             var now = DateTime.UtcNow.ToString("o");
             var newSession = new SessionRecord
             {
-                Id        = $"s-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}",
+                Id        = $"{AppDefaults.SessionIdPrefix}{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}",
                 Title     = "Neuer Chat",
                 CreatedAt = now,
                 UpdatedAt = now,

--- a/src/bashGPT/Shell/CommandExecutor.cs
+++ b/src/bashGPT/Shell/CommandExecutor.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using BashGPT;
 
 namespace BashGPT.Shell;
 
@@ -10,8 +11,8 @@ public class CommandExecutor(
     ExecutionMode mode = ExecutionMode.Ask,
     TextWriter? output = null,
     TextReader? input = null,
-    int maxOutputChars = 10_000,
-    int commandTimeoutSeconds = 30)
+    int maxOutputChars = AppDefaults.MaxCommandOutputChars,
+    int commandTimeoutSeconds = AppDefaults.CommandTimeoutSeconds)
 {
     private static readonly Regex InteractiveAlwaysPattern = new(
         @"^\s*(htop|btop|watch|less|more|man|vim|vi|nano|emacs)\b",


### PR DESCRIPTION
## Summary

**Backend – neue `AppDefaults`-Klasse** (`src/bashGPT/AppDefaults.cs`):
| Konstante | Wert | Verwendet in |
|---|---|---|
| `MaxToolCallRounds` | 3 | `PromptHandler` |
| `CommandTimeoutSeconds` | 30 | `CommandExecutor` |
| `MaxCommandOutputChars` | 10_000 | `CommandExecutor` |
| `MaxHistoryMessages` | 40 | `LegacyHistory` |
| `MaxProviderRetries` | 3 | `CerebrasProvider` |
| `SessionIdPrefix` | "s-" | `SessionApiHandler` |

**Frontend – neue `constants.ts`**:
- `CHAT_TIMEOUT_MS = 120_000` → importiert in `api.ts`
- `SESSION_ID_PREFIX = 's-'` → importiert in `chat-app.ts`

Session-ID-Format ist nun zwischen Backend und Frontend konsistent über dieselbe Konstante definiert.

## Test plan

- [x] `dotnet build` – 0 Fehler
- [x] `dotnet test` – 145/145 Tests grün

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Zentrale Konfigurationsverwaltung für Anwendungsstandards eingeführt, einschließlich Zeitlimits, Sitzungs-ID-Formate und Verlaufsgrenzen.
  * Session-IDs verwenden nun ein einheitliches Präfix-Format über alle Komponenten hinweg.
  * Kommunikations-Timeouts und Befehlszeitlimits standardisiert und zentralisiert konfigurierbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->