### PR TITLE
test(#55): Frontend Unit-Tests mit Vitest einführen (20 Tests)

### DIFF
--- a/src/bashGPT.Web/package-lock.json
+++ b/src/bashGPT.Web/package-lock.json
@@ -14,8 +14,10 @@
         "marked": "^17.0.3"
       },
       "devDependencies": {
+        "happy-dom": "^20.7.0",
         "typescript": "~5.9.3",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -460,6 +462,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
@@ -825,6 +834,31 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -832,11 +866,170 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/dompurify": {
       "version": "3.3.1",
@@ -846,6 +1039,26 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -889,6 +1102,26 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -920,6 +1153,25 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
+      "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/highlight.js": {
@@ -962,6 +1214,16 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
@@ -992,6 +1254,24 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1088,6 +1368,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1096,6 +1383,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1115,6 +1433,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1129,12 +1457,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1200,6 +1536,133 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/src/bashGPT.Web/package.json
+++ b/src/bashGPT.Web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "dompurify": "^3.2.7",
@@ -15,7 +16,9 @@
     "marked": "^17.0.3"
   },
   "devDependencies": {
+    "happy-dom": "^20.7.0",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/bashGPT.Web/src/tests/api.test.ts
+++ b/src/bashGPT.Web/src/tests/api.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getContext, getSettings, getSessions, sendChat } from '../api'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ── getSessions ───────────────────────────────────────────────────────────────
+
+describe('getSessions', () => {
+  it('returns null when fetch throws a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    expect(await getSessions()).toBeNull()
+  })
+
+  it('returns the sessions array on a successful response', async () => {
+    const sessions = [{ id: 's-1', title: 'Test', createdAt: '', updatedAt: '' }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessions }),
+    }))
+    expect(await getSessions()).toEqual(sessions)
+  })
+
+  it('returns null on a non-ok HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+    expect(await getSessions()).toBeNull()
+  })
+})
+
+// ── getContext ────────────────────────────────────────────────────────────────
+
+describe('getContext', () => {
+  it('returns null when the response status is not ok (e.g. 404)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+    expect(await getContext()).toBeNull()
+  })
+
+  it('returns context data on a successful response', async () => {
+    const ctx = { user: 'alice', host: 'mac', cwd: '/home', os: 'macOS', shell: 'zsh' }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ctx,
+    }))
+    expect(await getContext()).toEqual(ctx)
+  })
+})
+
+// ── getSettings ───────────────────────────────────────────────────────────────
+
+describe('getSettings', () => {
+  it('returns null when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
+    expect(await getSettings()).toBeNull()
+  })
+})
+
+// ── sendChat ──────────────────────────────────────────────────────────────────
+
+describe('sendChat', () => {
+  it('throws a timeout error when the request is aborted', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: RequestInit) => {
+      // Simulate abort signal being triggered
+      const signal = opts.signal as AbortSignal
+      if (signal?.aborted) {
+        return Promise.reject(new DOMException('Aborted', 'AbortError'))
+      }
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        )
+      })
+    }))
+
+    // Use a very short timeout by directly aborting via controller
+    const controller = new AbortController()
+    controller.abort()
+
+    // sendChat internally creates its own controller + timeout;
+    // we can only test the error path by triggering an AbortError
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError')))
+    await expect(sendChat('hello', 'auto-exec')).rejects.toThrow('Zeitlimit erreicht')
+  })
+})

--- a/src/bashGPT.Web/src/tests/chat-view.test.ts
+++ b/src/bashGPT.Web/src/tests/chat-view.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import type { CommandResult, TokenUsage } from '../types'
+
+// Private methods are accessed via `any` cast – a common pattern in TS unit tests.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let el: any
+
+describe('ChatView – private logic', () => {
+  beforeAll(async () => {
+    const mod = await import('../components/chat-view')
+    el = new mod.ChatView()
+  })
+
+  // ── _commandStats getter ─────────────────────────────────────────────────
+
+  it('_commandStats aggregates success / error / skipped correctly', () => {
+    const commands: CommandResult[] = [
+      { command: 'ls',   exitCode: 0, output: '', wasExecuted: true  }, // success
+      { command: 'rm',   exitCode: 1, output: '', wasExecuted: true  }, // error
+      { command: 'cat',  exitCode: 0, output: '', wasExecuted: false }, // skipped
+    ]
+    el._messages = [{ id: 1, role: 'user', content: 'test', commands }]
+    expect(el._commandStats).toEqual({ total: 3, success: 1, error: 1, skipped: 1 })
+  })
+
+  it('_commandStats returns all-zeros when messages have no commands', () => {
+    el._messages = [{ id: 1, role: 'user', content: 'hello' }]
+    expect(el._commandStats).toEqual({ total: 0, success: 0, error: 0, skipped: 0 })
+  })
+
+  // ── _sumTokenUsage method ────────────────────────────────────────────────
+
+  it('_sumTokenUsage sums inputTokens / outputTokens / cachedInputTokens across messages', () => {
+    const usage1: TokenUsage = { inputTokens: 10, outputTokens: 20, totalTokens: 30 }
+    const usage2: TokenUsage = { inputTokens: 5,  outputTokens: 15, totalTokens: 20, cachedInputTokens: 3 }
+    const messages = [
+      { id: 1, role: 'user',      content: 'a', usage: usage1 },
+      { id: 2, role: 'assistant', content: 'b', usage: usage2 },
+    ]
+    const result: TokenUsage = el._sumTokenUsage(messages)
+    expect(result.inputTokens).toBe(15)
+    expect(result.outputTokens).toBe(35)
+    expect(result.totalTokens).toBe(50)
+    expect(result.cachedInputTokens).toBe(3)
+  })
+})

--- a/src/bashGPT.Web/src/tests/session-history.test.ts
+++ b/src/bashGPT.Web/src/tests/session-history.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  readLocalSessions,
+  titleFromMessages,
+  upsertSession,
+  writeLocalSessions,
+  type LocalSession,
+} from '../session-history'
+
+// happy-dom v20 does not expose a full Storage API for localStorage;
+// we provide a minimal mock so that getItem / setItem / removeItem work.
+const STORAGE_KEY = 'bashgpt_sessions_v2'
+
+function makeLocalStorageMock() {
+  const store: Record<string, string> = {}
+  return {
+    getItem:    vi.fn((key: string) => store[key] ?? null),
+    setItem:    vi.fn((key: string, value: string) => { store[key] = value }),
+    removeItem: vi.fn((key: string) => { delete store[key] }),
+    _store: store,
+  }
+}
+
+let lsMock: ReturnType<typeof makeLocalStorageMock>
+
+beforeEach(() => {
+  lsMock = makeLocalStorageMock()
+  vi.stubGlobal('localStorage', lsMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ── readLocalSessions ─────────────────────────────────────────────────────────
+
+describe('readLocalSessions', () => {
+  it('returns an empty array when localStorage is empty', () => {
+    expect(readLocalSessions()).toEqual([])
+  })
+
+  it('returns parsed sessions when valid data is stored', () => {
+    const sessions: LocalSession[] = [{
+      id: 's-1',
+      title: 'Test',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      messages: [],
+    }]
+    lsMock._store[STORAGE_KEY] = JSON.stringify(sessions)
+    expect(readLocalSessions()).toEqual(sessions)
+  })
+
+  it('returns an empty array on malformed JSON', () => {
+    lsMock._store[STORAGE_KEY] = '{invalid json}'
+    expect(readLocalSessions()).toEqual([])
+  })
+
+  it('filters out entries that are missing required fields', () => {
+    const data = [
+      { id: 's-valid', title: 'Valid', createdAt: '', updatedAt: '', messages: [] },
+      { title: 'Missing id', messages: [] },
+      { id: 42, messages: [] }, // id is not a string
+    ]
+    lsMock._store[STORAGE_KEY] = JSON.stringify(data)
+    expect(readLocalSessions()).toHaveLength(1)
+    expect(readLocalSessions()[0].id).toBe('s-valid')
+  })
+})
+
+// ── upsertSession ─────────────────────────────────────────────────────────────
+
+describe('upsertSession', () => {
+  it('inserts a new session when the ID does not yet exist', () => {
+    const result = upsertSession([], 's-new', [{ role: 'user', content: 'Hello' }])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('s-new')
+    expect(result[0].title).toBe('Hello')
+  })
+
+  it('updates title and messages of an existing session', () => {
+    const initial = upsertSession([], 's-1', [{ role: 'user', content: 'First' }])
+    const updated = upsertSession(initial, 's-1', [{ role: 'user', content: 'Updated message' }])
+    expect(updated).toHaveLength(1)
+    expect(updated[0].title).toBe('Updated message')
+  })
+})
+
+// ── titleFromMessages ─────────────────────────────────────────────────────────
+
+describe('titleFromMessages', () => {
+  it('returns the first user message as the title', () => {
+    expect(titleFromMessages([
+      { role: 'assistant', content: 'Hi' },
+      { role: 'user', content: 'Show files' },
+    ])).toBe('Show files')
+  })
+
+  it('truncates titles longer than 40 characters', () => {
+    const long = 'a'.repeat(50)
+    expect(titleFromMessages([{ role: 'user', content: long }])).toBe('a'.repeat(40) + '…')
+  })
+
+  it('returns "Neuer Chat" when there are no user messages', () => {
+    expect(titleFromMessages([])).toBe('Neuer Chat')
+  })
+})
+
+// ── writeLocalSessions (smoke test) ──────────────────────────────────────────
+
+describe('writeLocalSessions', () => {
+  it('persists sessions to localStorage', () => {
+    const sessions: LocalSession[] = [{
+      id: 's-1', title: 'Saved', createdAt: '', updatedAt: '', messages: [],
+    }]
+    writeLocalSessions(sessions)
+    expect(lsMock.setItem).toHaveBeenCalledWith(STORAGE_KEY, JSON.stringify(sessions))
+  })
+})

--- a/src/bashGPT.Web/vitest.config.ts
+++ b/src/bashGPT.Web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+  },
+})


### PR DESCRIPTION
## Summary

Führt das erste Frontend-Testsetup mit **Vitest + happy-dom** ein.

### Setup
- `vitest@4` + `happy-dom` als Dev-Dependencies
- `vitest.config.ts` mit `environment: 'happy-dom'`
- `"test": "vitest run"` in `package.json`

### Tests: 20 gesamt, alle grün

**`api.test.ts`** (7 Tests):
- `getSessions` – null bei Netzwerkfehler / sessions-Array bei Erfolg / null bei non-ok
- `getContext` – null bei 404 / Daten bei Erfolg
- `getSettings` – null bei Netzwerkfehler
- `sendChat` – wirft Zeitlimit-Fehlermeldung bei AbortError

**`session-history.test.ts`** (10 Tests):
- `readLocalSessions` – leer / gültige Daten / malformed JSON / fehlende Felder gefiltert
- `upsertSession` – neue Session / bestehende Session aktualisieren
- `titleFromMessages` – erster User-Text / Truncate bei > 40 Zeichen / "Neuer Chat"
- `writeLocalSessions` – smoke test via `setItem`-Mock
> localStorage via `vi.stubGlobal` gemockt (happy-dom v20 implementiert kein vollständiges Storage-API)

**`chat-view.test.ts`** (3 Tests):
- `_commandStats` – korrekte Aggregation success/error/skipped
- `_commandStats` – alle Nullen bei leeren Nachrichten
- `_sumTokenUsage` – korrekte Akkumulierung über mehrere Nachrichten
> Private Methoden via `(instance as any)` getestet – gängiges TS-Testmuster

## Test plan

- [x] `npm test` (im `src/bashGPT.Web`-Verzeichnis) – 20/20 grün
- [x] `dotnet test` – 145/145 grün

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Testframework installiert und konfiguriert
  * Umfassende Testsuites für API-Funktionalität, Ansichtslogik und Sitzungsverwaltung hinzugefügt
  * Verbesserte Testabdeckung für Qualitätssicherung implementiert

<!-- end of auto-generated comment: release notes by coderabbit.ai -->