### PR TITLE
fix(#69): npm-PATH für snap-installiertes .NET auf Linux ergänzen

### DIFF
--- a/src/bashGPT/bashGPT.csproj
+++ b/src/bashGPT/bashGPT.csproj
@@ -19,7 +19,17 @@
   </ItemGroup>
 
   <Target Name="BuildWebFrontend" BeforeTargets="BeforeBuild">
-    <Exec Command="npm run build" WorkingDirectory="..\bashGPT.Web" />
+    <!--
+      Windows: npm is resolved via the normal PATH.
+      Linux/macOS: snap-installed .NET runs in a sandbox with a restricted PATH
+      that may exclude /usr/bin and /usr/local/bin. We prepend the common npm
+      locations so that system-installed (apt) and nvm-managed npm are both found.
+    -->
+    <Exec Command="npm run build" WorkingDirectory="..\bashGPT.Web"
+          Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <Exec Command="npm run build" WorkingDirectory="..\bashGPT.Web"
+          EnvironmentVariables="PATH=/usr/local/bin:/usr/bin:/bin:$(PATH)"
+          Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Problem

Auf Linux Mint mit snap-installiertem .NET SDK schlägt `dotnet build` fehl:

```
error MSB3073: Der Befehl "npm run build" wurde mit dem Code 127 beendet.
```

**Ursache:** Snap-Apps laufen in einer Sandbox mit eingeschränktem `PATH`. `/usr/bin` ist nicht enthalten, weshalb `npm` (apt-installiert unter `/usr/bin/npm`) nicht gefunden wird.

## Fix

Der `Exec`-Task wird auf Linux/macOS mit einem erweiterten `PATH` aufgerufen:

```
PATH=/usr/local/bin:/usr/bin:/bin:$PATH
```

Das deckt ab:
- **apt** → `/usr/bin/npm`
- **nvm** → `/usr/local/bin/npm` oder im bestehenden `$PATH`
- **Homebrew (macOS)** → `/usr/local/bin/npm`

Windows-Verhalten bleibt unverändert.

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Verbesserungen

* **Chores**
  * Optimierte Build-Konfiguration für verbesserte Zuverlässigkeit und Kompatibilität auf Linux- und macOS-Systemen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->