### PR TITLE
fix(#75): dotnet run auf Maschinen ohne net9 Runtime

### DIFF
--- a/src/bashGPT/bashGPT.csproj
+++ b/src/bashGPT/bashGPT.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Problem
Auf Linux-Mint-Systemen mit installiertem .NET SDK 10, aber ohne Microsoft.NETCore.App 9.0, schlug `dotnet run --project src/bashGPT` mit Framework-Fehler fehl.

## Lösung
- `src/bashGPT/bashGPT.csproj`: `<RollForward>Major</RollForward>` ergänzt.

Damit kann die `net9.0`-App auf einer verfügbaren höheren Runtime (z. B. 10.x) ausgeführt werden, wenn 9.0 nicht installiert ist.

Closes #75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionshinweise

* **Chores**
  * Aktualisiert die Build-Konfiguration zur Unterstützung zukünftiger Framework-Versionen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->