### PR TITLE
cleanup(#77): V1-Umschalter aus Einstellungen entfernen

### DIFF
--- a/src/bashGPT.Web/src/components/settings-view.ts
+++ b/src/bashGPT.Web/src/components/settings-view.ts
@@ -211,11 +211,6 @@ export class SettingsView extends LitElement {
     this.dispatchEvent(new CustomEvent('clear-history', { bubbles: true, composed: true }))
   }
 
-  private _switchToV1() {
-    localStorage.removeItem('bashgpt_ui_v2')
-    location.reload()
-  }
-
   render() {
     const s = this._settings
 
@@ -333,9 +328,6 @@ export class SettingsView extends LitElement {
       <div class="actions">
         <button class="primary" @click=${this._save} ?disabled=${!s || this._loading}>
           ${this._loading ? 'Speichert…' : 'Speichern'}
-        </button>
-        <button class="danger" @click=${this._switchToV1}>
-          Zur alten UI wechseln
         </button>
       </div>
 


### PR DESCRIPTION
## Ziel
Alte UI-Umschaltung aus der Settings-View entfernen.

## Änderungen
- `src/bashGPT.Web/src/components/settings-view.ts`
  - Methode `_switchToV1()` entfernt
  - Button "Zur alten UI wechseln" entfernt

## Verifikation
- `npm --prefix src/bashGPT.Web run build`
- `dotnet test -v minimal`

Closes #77
