### PR TITLE
feat(#88): Coverage-Skript mit frischem HTML-Report einführen

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.2",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ _TeamCity*
 coverage*.json
 coverage*.xml
 coverage*.info
+coverage/
 
 # Visual Studio code coverage results
 *.coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - `dotnet run --project src/bashGPT.Server` starts the local server UI.
 - `dotnet test` runs all tests.
 - `dotnet test --collect:"XPlat Code Coverage"` generates coverage via coverlet.
+- `./scripts/coverage-report.sh` regenerates coverage from scratch and creates an HTML report.
 
 ## Coding Style & Naming Conventions
 - C# with nullable reference types enabled and implicit usings on.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Hinweis:
  dotnet test
 # mit Coverage
  dotnet test --collect:"XPlat Code Coverage"
+# vollständiger HTML-Report (inkl. vorherigem Cleanup)
+ ./scripts/coverage-report.sh
 ```
 
 ## Beispiele (Output-Format)

--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS_DIR="${ROOT_DIR}/TestResults"
+COVERAGE_DIR="${ROOT_DIR}/coverage"
+REPORT_DIR="${COVERAGE_DIR}/report"
+
+cd "${ROOT_DIR}"
+
+echo "[coverage] Cleaning old artifacts..."
+rm -rf "${RESULTS_DIR}" "${COVERAGE_DIR}"
+mkdir -p "${RESULTS_DIR}" "${REPORT_DIR}"
+
+echo "[coverage] Restoring .NET dependencies..."
+dotnet restore
+
+declare -a TEST_PROJECTS=()
+while IFS= read -r project; do
+  TEST_PROJECTS+=("${project}")
+done < <(find tests -type f -name "*.csproj" | sort)
+
+if [[ ${#TEST_PROJECTS[@]} -eq 0 ]]; then
+  echo "[coverage] No test projects found under tests/."
+  exit 1
+fi
+
+echo "[coverage] Running tests with OpenCover output..."
+for project in "${TEST_PROJECTS[@]}"; do
+  echo "[coverage] dotnet test ${project}"
+  dotnet test "${project}" \
+    --nologo \
+    --collect:"XPlat Code Coverage;Format=opencover" \
+    --results-directory "${RESULTS_DIR}" \
+    /m:1
+done
+
+declare -a COVERAGE_FILES=()
+while IFS= read -r file; do
+  COVERAGE_FILES+=("${file}")
+done < <(find "${RESULTS_DIR}" -type f -name "coverage.opencover.xml" | sort)
+
+if [[ ${#COVERAGE_FILES[@]} -eq 0 ]]; then
+  echo "[coverage] No coverage.opencover.xml files were generated."
+  exit 1
+fi
+
+if [[ ! -f "${ROOT_DIR}/.config/dotnet-tools.json" ]]; then
+  echo "[coverage] Initializing local dotnet tool manifest..."
+  dotnet new tool-manifest
+fi
+
+if ! dotnet tool list --local | grep -q "dotnet-reportgenerator-globaltool"; then
+  echo "[coverage] Installing ReportGenerator tool..."
+  dotnet tool install dotnet-reportgenerator-globaltool --local --version "5.*"
+fi
+
+echo "[coverage] Restoring local dotnet tools..."
+dotnet tool restore
+
+REPORTS_INPUT="$(printf '%s;' "${COVERAGE_FILES[@]}")"
+REPORTS_INPUT="${REPORTS_INPUT%;}"
+
+echo "[coverage] Generating HTML report..."
+dotnet tool run reportgenerator \
+  "-reports:${REPORTS_INPUT}" \
+  "-targetdir:${REPORT_DIR}" \
+  "-reporttypes:Html;HtmlSummary;TextSummary" \
+  "-riskhotspotassemblyfilters:+*" \
+  "-riskhotspotclassfilters:+*" \
+  "-title:bashGPT Coverage Report"
+
+echo
+if [[ -f "${REPORT_DIR}/Summary.txt" ]]; then
+  echo "[coverage] Summary:"
+  cat "${REPORT_DIR}/Summary.txt"
+  echo
+fi
+
+echo "[coverage] HTML report: ${REPORT_DIR}/index.html"


### PR DESCRIPTION
## Summary
- add reproducible coverage script: `scripts/coverage-report.sh`
- script deletes old coverage artifacts before each run (`TestResults/`, `coverage/`)
- run all test projects under `tests/` with OpenCover output
- generate fresh HTML coverage report via ReportGenerator at `coverage/report/index.html`
- add local tool manifest `.config/dotnet-tools.json` for deterministic tool setup
- ignore generated `coverage/` directory in `.gitignore`
- document script in `README.md` and `AGENTS.md`

## Validation
- executed: `./scripts/coverage-report.sh`
- result: script runs successfully, all tests pass, HTML report is generated
- example output path: `coverage/report/index.html`

## Issue
- closes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Funktionen
* Automatisiertes HTML-Testabdeckungsreporting hinzugefügt – Benutzer können jetzt detaillierte Abdeckungsberichte generieren.

## Documentation
* Dokumentation für die Ausführung von Testabdeckungsberichten aktualisiert.

## Chores
* Konfiguration für Code-Abdeckungs-Tools hinzugefügt.
* Abdeckungsverzeichnis zu Versionskontrolle-Ausschlüssen hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->