### PR TITLE
fix(#91): Tool-Call-Schleife korrekt erkennen

### DIFF
--- a/src/bashGPT.Core/AppDefaults.cs
+++ b/src/bashGPT.Core/AppDefaults.cs
@@ -1,3 +1,5 @@
+using BashGPT.Providers;
+
 namespace BashGPT;
 
 /// <summary>
@@ -6,7 +8,7 @@ namespace BashGPT;
 public static class AppDefaults
 {
     /// <summary>Maximale Tool-Call-Runden pro LLM-Anfrage in PromptHandler.</summary>
-    public const int MaxToolCallRounds = 3;
+    public const int MaxToolCallRounds = 8;
 
     /// <summary>Timeout pro Shell-Befehl in Sekunden (CommandExecutor).</summary>
     public const int CommandTimeoutSeconds = 30;
@@ -22,4 +24,38 @@ public static class AppDefaults
 
     /// <summary>Präfix für automatisch generierte Session-IDs.</summary>
     public const string SessionIdPrefix = "s-";
+
+    /// <summary>Meldung bei echter Tool-Call-Schleife (identische Befehle wiederholen sich).</summary>
+    public const string LoopDetectedMessage =
+        "Tool-Call-Schleife erkannt und beendet. " +
+        "Bitte nutze nicht-interaktive Befehle (z. B. 'ps aux --sort=-%cpu | head' statt 'top').";
+
+    /// <summary>Meldung wenn die maximale Anzahl an Tool-Call-Runden legitim erreicht wird.</summary>
+    public static readonly string MaxRoundsReachedMessage =
+        $"Maximale Anzahl Tool-Call-Runden ({MaxToolCallRounds}) erreicht. " +
+        "Die Aufgabe wurde möglicherweise nicht vollständig abgeschlossen.";
+
+    /// <summary>
+    /// Erkennt eine Tool-Call-Schleife: Gibt true zurück, wenn previous und current
+    /// dieselbe Anzahl Tool-Calls mit identischen Namen und ArgumentsJson (positionsbasiert) haben.
+    /// </summary>
+    public static bool DetectLoop(IReadOnlyList<ToolCall>? previous, IReadOnlyList<ToolCall> current)
+    {
+        if (previous is null || previous.Count == 0)
+            return false;
+        if (current.Count == 0)
+            return false;
+        if (previous.Count != current.Count)
+            return false;
+
+        for (var i = 0; i < current.Count; i++)
+        {
+            if (previous[i].Name != current[i].Name)
+                return false;
+            if (previous[i].ArgumentsJson != current[i].ArgumentsJson)
+                return false;
+        }
+
+        return true;
+    }
 }

--- a/src/bashGPT.Core/Cli/CliChatRunner.cs
+++ b/src/bashGPT.Core/Cli/CliChatRunner.cs
@@ -113,14 +113,24 @@ public class CliChatRunner(
         string? toolChoiceName,
         CancellationToken ct)
     {
-        var response = initialResponse;
-        var rounds   = 0;
+        var response          = initialResponse;
+        var rounds            = 0;
+        var previousToolCalls = (IReadOnlyList<ToolCall>?)null;
+        var loopDetected      = false;
 
         while (response.ToolCalls.Count > 0 && rounds < AppDefaults.MaxToolCallRounds)
         {
+            if (AppDefaults.DetectLoop(previousToolCalls, response.ToolCalls))
+            {
+                loopDetected = true;
+                break;
+            }
+            previousToolCalls = response.ToolCalls;
+            rounds++;
+
             var toolCalls = response.ToolCalls;
             if (opts.Verbose)
-                Console.Error.WriteLine($"[verbose] Tool-Call-Runde {rounds + 1}: {toolCalls.Count} Call(s)");
+                Console.Error.WriteLine($"[verbose] Tool-Call-Runde {rounds}: {toolCalls.Count} Call(s)");
 
             var (commands, errors) = ChatOrchestrator.ParseToolCalls(toolCalls);
             if (opts.Verbose)
@@ -138,9 +148,12 @@ public class CliChatRunner(
             Console.WriteLine();
             response = await StreamAndCollectAsync(provider, messages, tools, toolChoiceName, ct);
             Console.WriteLine();
-
-            rounds++;
         }
+
+        if (loopDetected)
+            Console.Error.WriteLine(AppDefaults.LoopDetectedMessage);
+        else if (response.ToolCalls.Count > 0)
+            Console.Error.WriteLine(AppDefaults.MaxRoundsReachedMessage);
     }
 
     private static async Task<LlmChatResponse> StreamAndCollectAsync(

--- a/src/bashGPT.Core/Cli/ServerChatRunner.cs
+++ b/src/bashGPT.Core/Cli/ServerChatRunner.cs
@@ -98,9 +98,18 @@ public class ServerChatRunner(
             if (opts.Verbose)
                 logs.Add($"Tool-Calls empfangen: {currentResponse.ToolCalls.Count}");
 
-            var rounds = 0;
+            var rounds            = 0;
+            var previousToolCalls = (IReadOnlyList<ToolCall>?)null;
+            var loopDetected      = false;
+
             while (currentResponse.ToolCalls.Count > 0 && rounds < AppDefaults.MaxToolCallRounds)
             {
+                if (AppDefaults.DetectLoop(previousToolCalls, currentResponse.ToolCalls))
+                {
+                    loopDetected = true;
+                    break;
+                }
+                previousToolCalls = currentResponse.ToolCalls;
                 rounds++;
                 var toolCalls = currentResponse.ToolCalls;
 
@@ -143,15 +152,23 @@ public class ServerChatRunner(
                 currentResponse    = nextResponse.Response;
             }
 
-            if (currentResponse.ToolCalls.Count > 0)
+            if (loopDetected || currentResponse.ToolCalls.Count > 0)
             {
-                var loopGuardMessage =
-                    "Tool-Call-Schleife erkannt und beendet. " +
-                    "Bitte nutze nicht-interaktive Befehle (z. B. 'ps aux --sort=-%cpu | head' statt 'top').";
-                if (opts.Verbose)
-                    logs.Add($"Maximale Tool-Call-Runden erreicht ({AppDefaults.MaxToolCallRounds}).");
+                string guardMessage;
+                if (loopDetected)
+                {
+                    if (opts.Verbose)
+                        logs.Add("Tool-Call-Schleife erkannt (identische Befehle wiederholt).");
+                    guardMessage = AppDefaults.LoopDetectedMessage;
+                }
+                else
+                {
+                    if (opts.Verbose)
+                        logs.Add($"Maximale Tool-Call-Runden erreicht ({AppDefaults.MaxToolCallRounds}).");
+                    guardMessage = AppDefaults.MaxRoundsReachedMessage;
+                }
                 var responseText = string.IsNullOrWhiteSpace(currentResponse.Content)
-                    ? loopGuardMessage
+                    ? guardMessage
                     : currentResponse.Content;
                 return new ServerChatResult(responseText, commandResults, logs, usedToolCalls, BuildUsage());
             }

--- a/tests/bashGPT.Cli.Tests/Cli/AppDefaultsLoopDetectionTests.cs
+++ b/tests/bashGPT.Cli.Tests/Cli/AppDefaultsLoopDetectionTests.cs
@@ -1,0 +1,92 @@
+using BashGPT.Providers;
+
+namespace BashGPT.Tests.Cli;
+
+/// <summary>
+/// Unit-Tests für AppDefaults.DetectLoop.
+/// </summary>
+public sealed class AppDefaultsLoopDetectionTests
+{
+    private static ToolCall Call(string name, string argsJson, string id = "tc-1") =>
+        new(id, name, argsJson);
+
+    private static ToolCall BashCall(string cmd, string id = "tc-1") =>
+        new(id, "bash", $$"""{"command":"{{cmd}}"}""");
+
+    [Fact]
+    public void DetectLoop_NullPrevious_ReturnsFalse()
+    {
+        var current = new[] { BashCall("ls") };
+        Assert.False(AppDefaults.DetectLoop(null, current));
+    }
+
+    [Fact]
+    public void DetectLoop_EmptyPrevious_ReturnsFalse()
+    {
+        var current = new[] { BashCall("ls") };
+        Assert.False(AppDefaults.DetectLoop([], current));
+    }
+
+    [Fact]
+    public void DetectLoop_EmptyCurrent_ReturnsFalse()
+    {
+        var previous = new[] { BashCall("ls") };
+        Assert.False(AppDefaults.DetectLoop(previous, []));
+    }
+
+    [Fact]
+    public void DetectLoop_DifferentCount_ReturnsFalse()
+    {
+        var previous = new[] { BashCall("ls", "tc-1") };
+        var current  = new[] { BashCall("ls", "tc-2"), BashCall("pwd", "tc-3") };
+        Assert.False(AppDefaults.DetectLoop(previous, current));
+    }
+
+    [Fact]
+    public void DetectLoop_IdenticalSingleCall_DifferentId_ReturnsTrue()
+    {
+        var previous = new[] { BashCall("ls", "tc-1") };
+        var current  = new[] { BashCall("ls", "tc-2") };
+        Assert.True(AppDefaults.DetectLoop(previous, current));
+    }
+
+    [Fact]
+    public void DetectLoop_DifferentCommand_ReturnsFalse()
+    {
+        var previous = new[] { BashCall("ls",  "tc-1") };
+        var current  = new[] { BashCall("pwd", "tc-2") };
+        Assert.False(AppDefaults.DetectLoop(previous, current));
+    }
+
+    [Fact]
+    public void DetectLoop_DifferentToolName_ReturnsFalse()
+    {
+        var previous = new[] { Call("bash",  """{"command":"ls"}""", "tc-1") };
+        var current  = new[] { Call("shell", """{"command":"ls"}""", "tc-2") };
+        Assert.False(AppDefaults.DetectLoop(previous, current));
+    }
+
+    [Fact]
+    public void DetectLoop_IdenticalMultipleCalls_ReturnsTrue()
+    {
+        var previous = new[] { BashCall("ls", "tc-1"), BashCall("pwd", "tc-2") };
+        var current  = new[] { BashCall("ls", "tc-3"), BashCall("pwd", "tc-4") };
+        Assert.True(AppDefaults.DetectLoop(previous, current));
+    }
+
+    [Fact]
+    public void DetectLoop_SameCommandsDifferentOrder_ReturnsFalse()
+    {
+        var previous = new[] { BashCall("ls", "tc-1"), BashCall("pwd", "tc-2") };
+        var current  = new[] { BashCall("pwd", "tc-3"), BashCall("ls", "tc-4") };
+        Assert.False(AppDefaults.DetectLoop(previous, current));
+    }
+
+    [Fact]
+    public void DetectLoop_WhitespaceDifferenceInJson_ReturnsFalse()
+    {
+        var previous = new[] { Call("bash", """{"command":"ls"}""",  "tc-1") };
+        var current  = new[] { Call("bash", """{ "command": "ls" }""", "tc-2") };
+        Assert.False(AppDefaults.DetectLoop(previous, current));
+    }
+}

--- a/tests/bashGPT.Cli.Tests/Cli/ServerChatRunnerTests.cs
+++ b/tests/bashGPT.Cli.Tests/Cli/ServerChatRunnerTests.cs
@@ -111,19 +111,17 @@ public sealed class ServerChatRunnerTests
     }
 
     [Fact]
-    public async Task RunServerChatAsync_FourConsecutiveToolCalls_ReturnsLoopGuardMessage()
+    public async Task RunServerChatAsync_IdenticalConsecutiveToolCalls_ReturnsLoopDetectedMessage()
     {
         var provider = new FakeLlmProvider();
         provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-1")]));
         provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-2")]));
-        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-3")]));
-        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-4")]));
         var sut = CreateRunner(provider);
 
         var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
 
-        Assert.Contains("Tool-Call-Schleife", result.Response);
-        Assert.Equal(4, provider.CallCount);
+        Assert.Contains("Schleife", result.Response);
+        Assert.Equal(2, provider.CallCount);
     }
 
     [Fact]
@@ -131,15 +129,55 @@ public sealed class ServerChatRunnerTests
     {
         var provider = new FakeLlmProvider();
         provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-1")]));
-        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-2")]));
-        provider.Enqueue(new LlmChatResponse("", [BashCall("top", "tc-3")]));
-        // 4. Antwort hat Tool-Calls UND Content → Content wird zurückgegeben
-        provider.Enqueue(new LlmChatResponse("Eigene Antwort trotz Tool-Call.", [BashCall("top", "tc-4")]));
+        // 2. Antwort hat Tool-Calls UND Content → Content wird zurückgegeben
+        provider.Enqueue(new LlmChatResponse("Eigene Antwort trotz Tool-Call.", [BashCall("top", "tc-2")]));
         var sut = CreateRunner(provider);
 
         var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
 
         Assert.Equal("Eigene Antwort trotz Tool-Call.", result.Response);
+        Assert.Equal(2, provider.CallCount);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_MaxRoundsReachedWithDifferentCalls_ReturnsMaxRoundsMessage()
+    {
+        // 9 Antworten mit je verschiedenen Befehlen → nach 8 Runden kein Loop, aber MaxRounds erreicht
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd1", "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd2", "tc-2")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd3", "tc-3")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd4", "tc-4")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd5", "tc-5")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd6", "tc-6")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd7", "tc-7")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd8", "tc-8")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("cmd9", "tc-9")]));
+        var sut = CreateRunner(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.DoesNotContain("Schleife", result.Response);
+        Assert.Contains("Maximale Anzahl", result.Response);
+        Assert.Equal(9, provider.CallCount);
+        Assert.True(result.UsedToolCalls);
+    }
+
+    [Fact]
+    public async Task RunServerChatAsync_DifferentToolCallsEachRound_NoLoopDetected()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse("", [BashCall("ls",   "tc-1")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("pwd",  "tc-2")]));
+        provider.Enqueue(new LlmChatResponse("", [BashCall("date", "tc-3")]));
+        provider.Enqueue(new LlmChatResponse("Fertig!", []));
+        var sut = CreateRunner(provider);
+
+        var result = await sut.RunServerChatAsync(Opts(execMode: ExecutionMode.DryRun));
+
+        Assert.Equal("Fertig!", result.Response);
+        Assert.DoesNotContain("Schleife", result.Response);
+        Assert.Equal(4, provider.CallCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `MaxToolCallRounds` von 3 auf 8 erhöht – legitime mehrstufige Aufgaben werden nicht mehr fälschlicherweise abgebrochen
- Neue `DetectLoop()`-Methode in `AppDefaults`: erkennt echte Endlosschleifen anhand identischer Tool-Call-Namen und `ArgumentsJson` (positionsbasiert, kein JSON-Parsing)
- Zwei separate Meldungskonstanten: `LoopDetectedMessage` (bei echter Schleife) und `MaxRoundsReachedMessage` (bei legitimem Rundenlimit)
- `ServerChatRunner` und `CliChatRunner` unterscheiden jetzt klar zwischen beiden Fällen

## Test plan

- [ ] `AppDefaultsLoopDetectionTests` – 10 Unit-Tests für `DetectLoop` (null/leer, verschiedene Anzahl, identisch, verschiedene Befehle, Tool-Name, Reihenfolge, Whitespace)
- [ ] `ServerChatRunnerTests` – bestehende Loop-Tests auf `CallCount = 2` angepasst, zwei neue Tests für MaxRounds und normale Mehrrundenausführung
- [ ] `dotnet test` – alle 182 Tests bestanden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Neue Features**
  * Schleifenerkennung für Tool-Aufrufe hinzugefügt, um wiederholte Befehle zu erkennen und automatisch zu unterbrechen.
  * Maximale Anzahl von Tool-Call-Runden von 3 auf 8 erhöht.

* **Bug Fixes**
  * Verbessertes Handling bei Erkennung von Befehlsschleifen mit aussagekräftigen Fehlermeldungen.

* **Tests**
  * Umfangreiche Test-Suite für die Schleifenerkennung hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->