### PR TITLE
feat(agents): Tools per Code registrieren und Agenten über Web-UI zuweisen

### DIFF
--- a/src/bashGPT.Agents/AgentBootstrap.cs
+++ b/src/bashGPT.Agents/AgentBootstrap.cs
@@ -1,3 +1,6 @@
+using BashGPT.Tools.Execution;
+using BashGPT.Tools.Shell;
+
 namespace BashGPT.Agents;
 
 public static class AgentBootstrap
@@ -12,4 +15,6 @@ public static class AgentBootstrap
         var agentsFile = Path.Combine(baseDir, "agents.json");
         return new AgentStore(agentsFile);
     }
+
+    public static ToolRegistry CreateToolRegistry() => new([new ShellExecTool()]);
 }

--- a/src/bashGPT.Agents/AgentRecord.cs
+++ b/src/bashGPT.Agents/AgentRecord.cs
@@ -23,6 +23,7 @@ public sealed class AgentRecord
     public string? SystemPrompt { get; set; }
     public string? LoopInstruction { get; set; }
     public string? ExecMode { get; set; }
+    public List<string> EnabledTools { get; set; } = [];
     public bool IsActive { get; set; } = true;
 
     // Runtime-State

--- a/src/bashGPT.Agents/Checks/LlmAgentCheck.cs
+++ b/src/bashGPT.Agents/Checks/LlmAgentCheck.cs
@@ -1,10 +1,12 @@
 using BashGPT.Providers;
 using BashGPT.Shell;
 using BashGPT.Storage;
+using BashGPT.Tools.Abstractions;
+using BashGPT.Tools.Execution;
 
 namespace BashGPT.Agents;
 
-public sealed class LlmAgentCheck(ILlmProvider? provider, SessionStore? sessionStore = null) : IAgentCheck
+public sealed class LlmAgentCheck(ILlmProvider? provider, SessionStore? sessionStore = null, ToolRegistry? toolRegistry = null) : IAgentCheck
 {
     private const int MaxRounds = 5;
 
@@ -47,7 +49,10 @@ public sealed class LlmAgentCheck(ILlmProvider? provider, SessionStore? sessionS
 
         messages.Add(new(ChatRole.User, agent.LoopInstruction));
 
-        var tools = new[] { ToolDefinitions.Bash };
+        var enabledITools = BuildEnabledTools(agent);
+        var tools = enabledITools.Count > 0
+            ? enabledITools.Select(t => ToLlmToolDefinition(t.Definition)).ToArray()
+            : [ToolDefinitions.Bash];
         var lastContent = "";
         var commandsThisRun = new List<SessionCommand>();
 
@@ -69,7 +74,19 @@ public sealed class LlmAgentCheck(ILlmProvider? provider, SessionStore? sessionS
             foreach (var call in response.ToolCalls)
             {
                 string toolResult;
-                if (ToolCallParsing.TryGetCommand(call, out var command, out var parseError))
+                if (enabledITools.Count > 0 && toolRegistry is not null && toolRegistry.TryGet(call.Name, out var iTool) && iTool is not null)
+                {
+                    var iResult = await iTool.ExecuteAsync(new BashGPT.Tools.Abstractions.ToolCall(call.Name, call.ArgumentsJson ?? "{}"), ct);
+                    toolResult = iResult.Content;
+                    commandsThisRun.Add(new SessionCommand
+                    {
+                        Command     = call.Name,
+                        Output      = toolResult,
+                        ExitCode    = iResult.Success ? 0 : 1,
+                        WasExecuted = true,
+                    });
+                }
+                else if (ToolCallParsing.TryGetCommand(call, out var command, out var parseError))
                 {
                     toolResult = await ExecuteCommandAsync(executor, command, execMode, ct);
                     var (exitCode, wasExecuted) = ParseToolResult(toolResult);
@@ -172,4 +189,34 @@ public sealed class LlmAgentCheck(ILlmProvider? provider, SessionStore? sessionS
         "dry-run"   or "dryrun"   => ExecutionMode.DryRun,
         _                         => ExecutionMode.NoExec,
     };
+
+    private List<ITool> BuildEnabledTools(AgentRecord agent)
+    {
+        if (toolRegistry is null || agent.EnabledTools.Count == 0)
+            return [];
+        var result = new List<ITool>();
+        foreach (var name in agent.EnabledTools)
+            if (toolRegistry.TryGet(name, out var t) && t is not null)
+                result.Add(t);
+        return result;
+    }
+
+    private static BashGPT.Providers.ToolDefinition ToLlmToolDefinition(BashGPT.Tools.Abstractions.ToolDefinition def)
+    {
+        var required = def.Parameters
+            .Where(p => p.Required)
+            .Select(p => p.Name)
+            .ToArray();
+
+        var properties = def.Parameters.ToDictionary(
+            p => p.Name,
+            p => p.Type == "object"
+                ? (object)new { type = p.Type, description = p.Description, additionalProperties = new { type = "string" } }
+                : (object)new { type = p.Type, description = p.Description });
+
+        return new BashGPT.Providers.ToolDefinition(
+            Name: def.Name,
+            Description: def.Description,
+            Parameters: new { type = "object", properties, required });
+    }
 }

--- a/src/bashGPT.Agents/bashGPT.Agents.csproj
+++ b/src/bashGPT.Agents/bashGPT.Agents.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\bashGPT.Core\bashGPT.Core.csproj" />
+    <ProjectReference Include="..\bashGPT.Tools\bashGPT.Tools.csproj" />
+    <ProjectReference Include="..\bashGPT.Tools.Shell\bashGPT.Tools.Shell.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/bashGPT.Server/Program.cs
+++ b/src/bashGPT.Server/Program.cs
@@ -11,7 +11,8 @@ var contextCollector = new ShellContextCollector();
 var serverRunner = new ServerChatRunner(configService, contextCollector);
 var sessionStore = AppBootstrap.CreateSessionStore();
 var agentStore = AgentBootstrap.CreateAgentStore();
-var serverHost = new ServerHost(serverRunner, configService, sessionStore, agentStore);
+var toolRegistry = AgentBootstrap.CreateToolRegistry();
+var serverHost = new ServerHost(serverRunner, configService, sessionStore, agentStore, toolRegistry);
 
 var providerOpt = new Option<string?>("--provider", "-p")
 {

--- a/src/bashGPT.Server/Server/AgentApiHandler.cs
+++ b/src/bashGPT.Server/Server/AgentApiHandler.cs
@@ -2,10 +2,11 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using BashGPT.Agents;
+using BashGPT.Tools.Execution;
 
 namespace BashGPT.Server;
 
-internal sealed class AgentApiHandler(AgentStore? agentStore)
+internal sealed class AgentApiHandler(AgentStore? agentStore, ToolRegistry? toolRegistry = null)
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -125,6 +126,7 @@ internal sealed class AgentApiHandler(AgentStore? agentStore)
             SystemPrompt    = body.SystemPrompt?.Trim(),
             LoopInstruction = body.LoopInstruction?.Trim(),
             ExecMode        = body.ExecMode?.Trim(),
+            EnabledTools    = FilterEnabledTools(body.EnabledTools),
             IsActive        = true,
         };
 
@@ -176,6 +178,8 @@ internal sealed class AgentApiHandler(AgentStore? agentStore)
             agent.LoopInstruction = loop.Trim();
         if (body?.ExecMode is not null)
             agent.ExecMode = body.ExecMode.Trim();
+        if (body?.EnabledTools is not null)
+            agent.EnabledTools = FilterEnabledTools(body.EnabledTools);
 
         await agentStore!.UpsertAsync(agent);
         await ApiResponse.WriteJsonAsync(ctx.Response, ToDto(agent));
@@ -202,6 +206,7 @@ internal sealed class AgentApiHandler(AgentStore? agentStore)
         systemPrompt       = a.SystemPrompt,
         loopInstruction    = a.LoopInstruction,
         execMode           = a.ExecMode,
+        enabledTools       = a.EnabledTools,
         isActive           = a.IsActive,
         lastRun            = a.LastRun,
         lastMessage        = a.LastMessage,
@@ -218,7 +223,8 @@ internal sealed class AgentApiHandler(AgentStore? agentStore)
         int? IntervalSeconds,
         string? SystemPrompt,
         string? LoopInstruction,
-        string? ExecMode);
+        string? ExecMode,
+        List<string>? EnabledTools = null);
 
     private sealed record PatchAgentRequest(
         bool?   IsActive,
@@ -226,5 +232,15 @@ internal sealed class AgentApiHandler(AgentStore? agentStore)
         int?    IntervalSeconds,
         string? SystemPrompt,
         string? LoopInstruction,
-        string? ExecMode);
+        string? ExecMode,
+        List<string>? EnabledTools = null);
+
+    private List<string> FilterEnabledTools(List<string>? requested)
+    {
+        if (requested is null || requested.Count == 0)
+            return [];
+        if (toolRegistry is null)
+            return requested;
+        return requested.Where(n => toolRegistry.TryGet(n, out _)).ToList();
+    }
 }

--- a/src/bashGPT.Server/Server/ServerHost.cs
+++ b/src/bashGPT.Server/Server/ServerHost.cs
@@ -6,6 +6,7 @@ using BashGPT.Configuration;
 using BashGPT.Providers;
 using BashGPT.Shell;
 using BashGPT.Storage;
+using BashGPT.Tools.Execution;
 
 namespace BashGPT.Server;
 
@@ -19,19 +20,23 @@ public class ServerHost
     private readonly StreamingChatApiHandler   _streamingChatHandler;
     private readonly SessionApiHandler         _sessionHandler;
     private readonly AgentApiHandler           _agentHandler;
+    private readonly ToolApiHandler            _toolHandler;
     private readonly ConfigurationService?     _configService;
     private readonly AgentStore?               _agentStore;
     private readonly SessionStore?             _sessionStore;
+    private readonly ToolRegistry?             _toolRegistry;
 
     public ServerHost(
         IPromptHandler handler,
         ConfigurationService? configService = null,
         SessionStore? sessionStore = null,
-        AgentStore? agentStore = null)
+        AgentStore? agentStore = null,
+        ToolRegistry? toolRegistry = null)
     {
         _configService        = configService;
         _agentStore           = agentStore;
         _sessionStore         = sessionStore;
+        _toolRegistry         = toolRegistry;
         _state                = new ServerState();
         _legacyHistory        = new LegacyHistory();
         _contextHandler       = new ContextApiHandler();
@@ -39,7 +44,8 @@ public class ServerHost
         _chatHandler          = new ChatApiHandler(handler, _state, _legacyHistory, sessionStore);
         _streamingChatHandler = new StreamingChatApiHandler(handler, _state, _legacyHistory, sessionStore);
         _sessionHandler       = new SessionApiHandler(sessionStore, _legacyHistory);
-        _agentHandler         = new AgentApiHandler(agentStore);
+        _agentHandler         = new AgentApiHandler(agentStore, toolRegistry);
+        _toolHandler          = new ToolApiHandler(toolRegistry);
     }
 
     public async Task<int> RunAsync(ServerOptions options, CancellationToken ct = default)
@@ -76,7 +82,7 @@ public class ServerHost
                 catch (Exception ex) { Console.Error.WriteLine($"[WARN] LLM für Agenten nicht verfügbar: {ex.Message}"); }
 
             var runner = new AgentRunner(_agentStore,
-                [new GitStatusCheck(), new HttpStatusCheck(), new BitcoinPriceCheck(), new LlmAgentCheck(agentProvider, _sessionStore)],
+                [new GitStatusCheck(), new HttpStatusCheck(), new BitcoinPriceCheck(), new LlmAgentCheck(agentProvider, _sessionStore, _toolRegistry)],
                 agentProvider, _sessionStore);
             _ = Task.Run(() => runner.RunAsync(ct), ct);
             Console.WriteLine($"Agent-Runner gestartet{(agentProvider is not null ? $" | LLM: {agentProvider.Name} ({agentProvider.Model})" : " | LLM: nicht konfiguriert")}.");
@@ -169,6 +175,9 @@ public class ServerHost
 
             if (path.StartsWith("/api/sessions", StringComparison.Ordinal))
             { await _sessionHandler.HandleAsync(ctx, ct); return; }
+
+            if (req.HttpMethod == "GET" && path == "/api/tools")
+            { await _toolHandler.HandleAsync(ctx.Response, ct); return; }
 
             if (path.StartsWith("/api/agents", StringComparison.Ordinal))
             { await _agentHandler.HandleAsync(ctx, ct); return; }

--- a/src/bashGPT.Server/Server/ToolApiHandler.cs
+++ b/src/bashGPT.Server/Server/ToolApiHandler.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using BashGPT.Tools.Execution;
+
+namespace BashGPT.Server;
+
+internal sealed class ToolApiHandler(ToolRegistry? toolRegistry)
+{
+    public async Task HandleAsync(HttpListenerResponse response, CancellationToken ct)
+    {
+        if (toolRegistry is null)
+        {
+            await ApiResponse.WriteJsonAsync(response, new { tools = Array.Empty<object>() });
+            return;
+        }
+
+        var tools = toolRegistry.Tools.Select(t => new
+        {
+            name        = t.Definition.Name,
+            description = t.Definition.Description,
+            parameters  = t.Definition.Parameters.Select(p => new
+            {
+                name        = p.Name,
+                type        = p.Type,
+                description = p.Description,
+                required    = p.Required,
+            }),
+        });
+
+        await ApiResponse.WriteJsonAsync(response, new { tools });
+    }
+}

--- a/src/bashGPT.Server/bashGPT.Server.csproj
+++ b/src/bashGPT.Server/bashGPT.Server.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <ProjectReference Include="..\bashGPT.Core\bashGPT.Core.csproj" />
     <ProjectReference Include="..\bashGPT.Agents\bashGPT.Agents.csproj" />
+    <ProjectReference Include="..\bashGPT.Tools\bashGPT.Tools.csproj" />
+    <ProjectReference Include="..\bashGPT.Tools.Shell\bashGPT.Tools.Shell.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/bashGPT.Tools.Shell/ShellExecTool.cs
+++ b/src/bashGPT.Tools.Shell/ShellExecTool.cs
@@ -19,7 +19,7 @@ public sealed class ShellExecTool : ITool
     }
 
     public ToolDefinition Definition { get; } = new(
-        Name: "shell.exec",
+        Name: "shell_exec",
         Description: "Executes a shell command and returns stdout, stderr, exit code, duration and timeout status.",
         Parameters:
         [

--- a/src/bashGPT.Web/src/api.ts
+++ b/src/bashGPT.Web/src/api.ts
@@ -1,4 +1,4 @@
-import type { Agent, ChatResponse, CommandResult, ExecMode, FullShellContext, HistoryMessage, Session, Settings } from './types'
+import type { Agent, ChatResponse, CommandResult, ExecMode, FullShellContext, HistoryMessage, Session, Settings, ToolInfo } from './types'
 import { CHAT_TIMEOUT_MS } from './constants'
 
 async function readErrorMessage(res: Response): Promise<string> {
@@ -258,6 +258,7 @@ export async function createAgent(payload: {
   systemPrompt?: string
   loopInstruction?: string
   execMode?: string
+  enabledTools?: string[]
 }): Promise<Agent> {
   const res = await fetch('/api/agents', {
     method: 'POST',
@@ -275,6 +276,7 @@ export async function patchAgent(id: string, patch: {
   systemPrompt?: string | null
   loopInstruction?: string
   execMode?: string
+  enabledTools?: string[]
 }): Promise<Agent> {
   const res = await fetch(`/api/agents/${id}`, {
     method: 'PATCH',
@@ -288,4 +290,15 @@ export async function patchAgent(id: string, patch: {
 export async function deleteAgent(id: string): Promise<void> {
   const res = await fetch(`/api/agents/${id}`, { method: 'DELETE' })
   await assertOk(res)
+}
+
+// ── Tools API ─────────────────────────────────────────────────────────────────
+
+export async function getTools(): Promise<ToolInfo[]> {
+  try {
+    const res = await fetch('/api/tools')
+    if (!res.ok) return []
+    const data = await res.json()
+    return Array.isArray(data.tools) ? data.tools : []
+  } catch { return [] }
 }

--- a/src/bashGPT.Web/src/components/agents-view.ts
+++ b/src/bashGPT.Web/src/components/agents-view.ts
@@ -1,12 +1,13 @@
 import { LitElement, html, css } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
-import type { Agent } from '../types'
-import { getAgents, createAgent, patchAgent, deleteAgent } from '../api'
+import type { Agent, ToolInfo } from '../types'
+import { getAgents, createAgent, patchAgent, deleteAgent, getTools } from '../api'
 
 @customElement('bashgpt-agents-view')
 export class AgentsView extends LitElement {
   @state() private _agents: Agent[] = []
+  @state() private _availableTools: ToolInfo[] = []
   @state() private _loading = true
   @state() private _error = ''
   @state() private _showForm = false
@@ -15,6 +16,7 @@ export class AgentsView extends LitElement {
   @state() private _formSystemPrompt = ''
   @state() private _formLoopInstruction = ''
   @state() private _formExecMode = 'no-exec'
+  @state() private _formEnabledTools: string[] = []
   @state() private _formError = ''
   @state() private _saving = false
 
@@ -24,6 +26,7 @@ export class AgentsView extends LitElement {
   @state() private _editSystemPrompt = ''
   @state() private _editLoopInstruction = ''
   @state() private _editExecMode = 'no-exec'
+  @state() private _editEnabledTools: string[] = []
   @state() private _editError = ''
   @state() private _editSaving = false
 
@@ -265,6 +268,36 @@ export class AgentsView extends LitElement {
       border-radius: 8px;
       border: 1px solid #7f1d1d;
     }
+
+    .tool-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .tool-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      color: #cbd5e1;
+      cursor: pointer;
+    }
+
+    .tool-item input[type="checkbox"] {
+      accent-color: #22c55e;
+      width: 14px;
+      height: 14px;
+      cursor: pointer;
+      padding: 0;
+      border: none;
+      background: none;
+    }
+
+    .tool-desc {
+      font-size: 11px;
+      color: #475569;
+    }
   `
 
   async connectedCallback() {
@@ -276,7 +309,7 @@ export class AgentsView extends LitElement {
     this._loading = true
     this._error = ''
     try {
-      this._agents = await getAgents()
+      [this._agents, this._availableTools] = await Promise.all([getAgents(), getTools()])
     } catch (e) {
       this._error = e instanceof Error ? e.message : String(e)
     } finally {
@@ -294,13 +327,14 @@ export class AgentsView extends LitElement {
   }
 
   private _startEdit(a: Agent) {
-    this._editingId        = a.id
-    this._editName         = a.name
-    this._editInterval     = a.intervalSeconds
-    this._editSystemPrompt = a.systemPrompt ?? ''
+    this._editingId           = a.id
+    this._editName            = a.name
+    this._editInterval        = a.intervalSeconds
+    this._editSystemPrompt    = a.systemPrompt ?? ''
     this._editLoopInstruction = a.loopInstruction ?? ''
-    this._editExecMode     = a.execMode ?? 'no-exec'
-    this._editError        = ''
+    this._editExecMode        = a.execMode ?? 'no-exec'
+    this._editEnabledTools    = [...(a.enabledTools ?? [])]
+    this._editError           = ''
   }
 
   private _cancelEdit() {
@@ -326,6 +360,7 @@ export class AgentsView extends LitElement {
         systemPrompt:    this._editSystemPrompt.trim() || null,
         ...(agent.type === 'llmagent' ? { loopInstruction: this._editLoopInstruction.trim() } : {}),
         execMode:        this._editExecMode,
+        enabledTools:    this._editEnabledTools,
       }
       const updated = await patchAgent(this._editingId!, patch)
       this._agents   = this._agents.map(a => a.id === updated.id ? updated : a)
@@ -361,6 +396,7 @@ export class AgentsView extends LitElement {
         systemPrompt:    this._formSystemPrompt.trim() || undefined,
         loopInstruction: this._formLoopInstruction.trim(),
         execMode:        this._formExecMode,
+        enabledTools:    this._formEnabledTools,
       })
       this._agents = [...this._agents, agent]
       this._resetForm()
@@ -378,7 +414,39 @@ export class AgentsView extends LitElement {
     this._formSystemPrompt = ''
     this._formLoopInstruction = ''
     this._formExecMode = 'no-exec'
+    this._formEnabledTools = []
     this._formError = ''
+  }
+
+  private _toggleTool(name: string, checked: boolean, target: 'form' | 'edit') {
+    const current = target === 'form' ? this._formEnabledTools : this._editEnabledTools
+    const updated = checked ? [...current, name] : current.filter(n => n !== name)
+    if (target === 'form') this._formEnabledTools = updated
+    else this._editEnabledTools = updated
+  }
+
+  private _renderToolList(selected: string[], target: 'form' | 'edit') {
+    if (this._availableTools.length === 0) return ''
+    return html`
+      <div class="form-row">
+        <label>Tools</label>
+        <div class="tool-list">
+          ${this._availableTools.map(t => html`
+            <label class="tool-item">
+              <input
+                type="checkbox"
+                .checked=${selected.includes(t.name)}
+                @change=${(e: Event) => this._toggleTool(t.name, (e.target as HTMLInputElement).checked, target)}
+              />
+              <span>
+                <strong>${t.name}</strong>
+                <span class="tool-desc"> — ${t.description}</span>
+              </span>
+            </label>
+          `)}
+        </div>
+      </div>
+    `
   }
 
   private _formatDate(iso?: string) {
@@ -497,6 +565,8 @@ export class AgentsView extends LitElement {
           />
         </div>
 
+        ${this._renderToolList(this._formEnabledTools, 'form')}
+
         ${this._formError ? html`<div class="form-error">${this._formError}</div>` : ''}
 
         <div class="form-actions">
@@ -558,6 +628,8 @@ export class AgentsView extends LitElement {
             @input=${(e: Event) => { this._editInterval = parseInt((e.target as HTMLInputElement).value) || 60 }}
           />
         </div>
+
+        ${this._renderToolList(this._editEnabledTools, 'edit')}
 
         ${this._editError ? html`<div class="form-error">${this._editError}</div>` : ''}
 

--- a/src/bashGPT.Web/src/types.ts
+++ b/src/bashGPT.Web/src/types.ts
@@ -105,10 +105,22 @@ export interface Agent {
   systemPrompt?: string
   loopInstruction?: string
   execMode?: string
+  enabledTools: string[]
   isActive: boolean
   lastRun?: string
   lastMessage?: string
   lastCheckSucceeded: boolean
+}
+
+export interface ToolInfo {
+  name: string
+  description: string
+  parameters: Array<{
+    name: string
+    type: string
+    description: string
+    required: boolean
+  }>
 }
 
 export type AppView = 'dashboard' | 'chat' | 'settings' | 'agents'

--- a/tests/bashGPT.Tools.Shell.Tests/ShellExecToolTests.cs
+++ b/tests/bashGPT.Tools.Shell.Tests/ShellExecToolTests.cs
@@ -11,7 +11,7 @@ public class ShellExecToolTests
         var args = new Dictionary<string, object?> { ["command"] = command };
         if (cwd is not null) args["cwd"] = cwd;
         if (timeoutMs is not null) args["timeoutMs"] = timeoutMs;
-        return new ToolCall("shell.exec", JsonSerializer.Serialize(args));
+        return new ToolCall("shell_exec", JsonSerializer.Serialize(args));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #113

## Summary

- **ToolRegistry**: `AgentBootstrap.CreateToolRegistry()` registriert `shell_exec`-Tool per Code
- **GET /api/tools**: Neuer Endpunkt gibt alle registrierten Tools als JSON zurück
- **Agent-Tool-Zuweisung**: `enabledTools`-Liste im `AgentRecord` gespeichert und über API verwaltbar
- **LlmAgentCheck**: Filtert Tools aus Registry anhand der Agent-`enabledTools`-Liste beim LLM-Aufruf
- **Frontend**: Tool-Checkboxen in Agent-Erstellen- und Bearbeiten-Formular

## Technische Details

- Cerebras-Kompatibilität: Tool-Name `shell_exec` (kein Punkt erlaubt laut `^[a-zA-Z0-9_-]+$`)
- `object`-Parameter erhalten `additionalProperties: { type: "string" }` für Cerebras-Grammatik-Kompilierung
- Tool-Dispatch in `LlmAgentCheck`: registrierte Tools via `ITool.ExecuteAsync()`, Fallback auf `CommandExecutor` für `bash`

## Test plan

- [ ] Server starten, `GET /api/tools` gibt `shell_exec` zurück
- [ ] Agenten erstellen mit aktivierten Tools, `enabledTools` wird gespeichert
- [ ] LLM-Agent mit `shell_exec` ruft das Tool korrekt auf
- [ ] 219 Tests grün (`dotnet test`)