### PR TITLE
fix: persistiere Tool-Fehler und AgentId in Sessions

### DIFF
--- a/src/bashGPT.Core/Cli/ServerChatRunner.cs
+++ b/src/bashGPT.Core/Cli/ServerChatRunner.cs
@@ -137,10 +137,18 @@ public class ServerChatRunner(
                     string toolResult;
                     if (toolRegistry.TryGet(call.Name, out var iTool) && iTool is not null)
                     {
-                        var r = await iTool.ExecuteAsync(
-                            new Tools.Abstractions.ToolCall(call.Name, call.ArgumentsJson ?? "{}"), ct);
-                        toolResult = r.Success ? r.Content : $"Fehler: {r.Content}";
-                        commandResult = BuildCommandResult(call.Name, commandLabel, toolResult, r.Success);
+                        try
+                        {
+                            var r = await iTool.ExecuteAsync(
+                                new Tools.Abstractions.ToolCall(call.Name, call.ArgumentsJson ?? "{}"), ct);
+                            toolResult = r.Success ? r.Content : $"Fehler: {r.Content}";
+                            commandResult = BuildCommandResult(call.Name, commandLabel, toolResult, r.Success);
+                        }
+                        catch (Exception ex) when (ex is not OperationCanceledException)
+                        {
+                            toolResult = $"Fehler: {ex.Message}";
+                            commandResult = new CommandResult(commandLabel, 1, toolResult, WasExecuted: false);
+                        }
                     }
                     else
                     {

--- a/src/bashGPT.Core/Storage/SessionStore.cs
+++ b/src/bashGPT.Core/Storage/SessionStore.cs
@@ -80,6 +80,7 @@ public class SessionStore
             Messages     = content.Messages,
             ShellContext = content.ShellContext,
             EnabledTools = content.EnabledTools,
+            AgentId      = content.AgentId,
         };
     }
 
@@ -101,6 +102,7 @@ public class SessionStore
                 Messages     = session.Messages,
                 ShellContext = session.ShellContext,
                 EnabledTools = session.EnabledTools,
+                AgentId      = session.AgentId,
             };
             await WriteContentInternalAsync(session.Id, content);
 
@@ -352,6 +354,8 @@ public class SessionStore
                 {
                     Messages     = session.Messages,
                     ShellContext = session.ShellContext,
+                    EnabledTools = session.EnabledTools,
+                    AgentId      = session.AgentId,
                 };
                 await WriteContentInternalAsync(session.Id, content);
                 indexEntries.Add(new SessionIndexEntry

--- a/tests/bashGPT.Cli.Tests/Cli/ServerChatRunnerTests.cs
+++ b/tests/bashGPT.Cli.Tests/Cli/ServerChatRunnerTests.cs
@@ -1,4 +1,4 @@
-using BashGPT.Cli;
+﻿using BashGPT.Cli;
 using BashGPT.Configuration;
 using BashGPT.Providers;
 using BashGPT.Tools.Execution;
@@ -7,12 +7,12 @@ using System.Reflection;
 namespace BashGPT.Cli.Tests;
 
 /// <summary>
-/// Unit-Tests für ServerChatRunner.RunServerChatAsync.
-/// Nutzt FakeLlmProvider (via providerOverride) – reines LLM-Chat ohne Tools.
+/// Unit-Tests fÃ¼r ServerChatRunner.RunServerChatAsync.
+/// Nutzt FakeLlmProvider (via providerOverride) â€“ reines LLM-Chat ohne Tools.
 /// </summary>
 public sealed class ServerChatRunnerTests
 {
-    // ── Hilfsmethoden ───────────────────────────────────────────────────────
+    // â”€â”€ Hilfsmethoden â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     private static ServerChatRunner CreateRunner(FakeLlmProvider provider) =>
         new(new ConfigurationService(), provider);
@@ -28,7 +28,7 @@ public sealed class ServerChatRunnerTests
             Model:    null,
             Verbose:  verbose);
 
-    // ── Tests ────────────────────────────────────────────────────────────────
+    // â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [Fact]
     public async Task RunServerChatAsync_SimpleText_ReturnsContent()
@@ -111,8 +111,8 @@ public sealed class ServerChatRunnerTests
     {
         var history = new List<ChatMessage>
         {
-            new(ChatRole.User,      "Frühere Frage"),
-            new(ChatRole.Assistant, "Frühere Antwort"),
+            new(ChatRole.User,      "FrÃ¼here Frage"),
+            new(ChatRole.Assistant, "FrÃ¼here Antwort"),
         };
         var provider = new FakeLlmProvider();
         provider.Enqueue(new LlmChatResponse("Antwort.", []));
@@ -122,9 +122,9 @@ public sealed class ServerChatRunnerTests
 
         Assert.NotNull(provider.LastRequestMessages);
         Assert.Contains(provider.LastRequestMessages!, m =>
-            m.Role == ChatRole.User && m.Content == "Frühere Frage");
+            m.Role == ChatRole.User && m.Content == "FrÃ¼here Frage");
         Assert.Contains(provider.LastRequestMessages!, m =>
-            m.Role == ChatRole.Assistant && m.Content == "Frühere Antwort");
+            m.Role == ChatRole.Assistant && m.Content == "FrÃ¼here Antwort");
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public sealed class ServerChatRunnerTests
         }
     }
 
-    // ── Tool-Call-Loop-Tests ─────────────────────────────────────────────────
+    // â”€â”€ Tool-Call-Loop-Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [Fact]
     public async Task RunServerChatAsync_WithToolsAndNoToolCallsInResponse_SingleLlmCall()
@@ -284,7 +284,7 @@ public sealed class ServerChatRunnerTests
     [Fact]
     public async Task RunServerChatAsync_WithTools_MaxRoundsReached_StopsLoop()
     {
-        // Immer Tool-Calls zurückgeben → Loop soll nach MaxToolRounds stoppen
+        // Immer Tool-Calls zurÃ¼ckgeben â†’ Loop soll nach MaxToolRounds stoppen
         var provider = new FakeLlmProvider();
         for (var i = 0; i < 10; i++)
         {
@@ -317,7 +317,7 @@ public sealed class ServerChatRunnerTests
     [Fact]
     public async Task RunServerChatAsync_WithoutToolRegistry_ToolCallsNotExecuted()
     {
-        // Kein Registry → Loop wird nie gestartet, auch wenn Tools in opts stehen
+        // Kein Registry â†’ Loop wird nie gestartet, auch wenn Tools in opts stehen
         var provider = new FakeLlmProvider();
         provider.Enqueue(new LlmChatResponse(
             "Antwort mit Tool-Call.",
@@ -340,7 +340,41 @@ public sealed class ServerChatRunnerTests
         Assert.Equal(1, provider.CallCount); // nur ein Aufruf
     }
 
-    // ── LlmExchanges-Tests ───────────────────────────────────────────────────
+    [Fact]
+    public async Task RunServerChatAsync_WithTools_ToolThrows_PreservesToolCallFlow()
+    {
+        var provider = new FakeLlmProvider();
+        provider.Enqueue(new LlmChatResponse(
+            "Ich rufe ein Tool auf.",
+            [new Providers.ToolCall("call-1", "my_tool", "{\"path\":\"\"}")]));
+        provider.Enqueue(new LlmChatResponse("Fehler verarbeitet.", []));
+
+        var fakeTool = new FakeTool("my_tool", throwException: new ArgumentException("The path is empty. (Parameter 'path')"));
+        var registry = new ToolRegistry([fakeTool]);
+        var sut      = new ServerChatRunner(new ConfigurationService(), provider, registry);
+
+        var tools = new[] { new Providers.ToolDefinition("my_tool", "Ein Tool", new { }) };
+        var opts  = new ServerChatOptions(
+            Prompt:   "Benutze Tool",
+            History:  [],
+            Provider: null,
+            Model:    null,
+            Verbose:  false,
+            Tools:    tools);
+
+        var result = await sut.RunServerChatAsync(opts);
+
+        Assert.Equal("Fehler verarbeitet.", result.Response);
+        Assert.Equal(2, provider.CallCount);
+        Assert.Equal(1, fakeTool.CallCount);
+        Assert.NotNull(provider.LastRequestMessages);
+        Assert.Contains(provider.LastRequestMessages!, m =>
+            m.Role == ChatRole.Tool &&
+            m.ToolCallId == "call-1" &&
+            m.Content.Contains("The path is empty.", StringComparison.Ordinal));
+    }
+
+    // â”€â”€ LlmExchanges-Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [Fact]
     public async Task RunServerChatAsync_SimpleResponse_OneLlmExchange()
@@ -357,7 +391,7 @@ public sealed class ServerChatRunnerTests
         Assert.NotNull(result.LlmExchanges[0].ResponseJson);
     }
 
-    // ── Rate-Limiter-Tests ───────────────────────────────────────────────────
+    // â”€â”€ Rate-Limiter-Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [Fact]
     public void GetOrCreateLimiter_ReusesAndRecreates_ByConfig()
@@ -400,26 +434,32 @@ public sealed class ServerChatRunnerTests
     }
 }
 
-// ── FakeTool ─────────────────────────────────────────────────────────────────
+// â”€â”€ FakeTool â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 internal sealed class FakeTool : BashGPT.Tools.Abstractions.ITool
 {
     private readonly string _returnValue;
+    private readonly Exception? _throwException;
 
     public int CallCount { get; private set; }
 
     public BashGPT.Tools.Abstractions.ToolDefinition Definition { get; }
 
-    public FakeTool(string name, string returnValue = "Tool-Ergebnis")
+    public FakeTool(string name, string returnValue = "Tool-Ergebnis", Exception? throwException = null)
     {
         _returnValue = returnValue;
-        Definition   = new BashGPT.Tools.Abstractions.ToolDefinition(name, "Fake-Tool für Tests", []);
+        _throwException = throwException;
+        Definition   = new BashGPT.Tools.Abstractions.ToolDefinition(name, "Fake-Tool fuer Tests", []);
     }
 
     public Task<BashGPT.Tools.Abstractions.ToolResult> ExecuteAsync(
         BashGPT.Tools.Abstractions.ToolCall call, CancellationToken ct)
     {
         CallCount++;
+        if (_throwException is not null)
+            throw _throwException;
+
         return Task.FromResult(new BashGPT.Tools.Abstractions.ToolResult(true, _returnValue));
     }
 }
+

--- a/tests/bashGPT.Core.Tests/Storage/SessionStoreTests.cs
+++ b/tests/bashGPT.Core.Tests/Storage/SessionStoreTests.cs
@@ -755,6 +755,38 @@ public sealed class SessionStoreTests : IDisposable
         Assert.Contains("http_check", loaded.EnabledTools);
     }
 
+    [Fact]
+    public async Task UpsertAsync_WithAgentId_PersistsAndLoadsAgentId()
+    {
+        var store   = CreateStore();
+        var session = MakeSession("s1");
+        session.AgentId = "agent-planner";
+
+        await store.UpsertAsync(session);
+        var loaded = await store.LoadAsync("s1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("agent-planner", loaded!.AgentId);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_UpdateAgentId_PersistsNewValue()
+    {
+        var store   = CreateStore();
+        var session = MakeSession("s1");
+        session.AgentId = "agent-a";
+        await store.UpsertAsync(session);
+
+        var updated = MakeSession("s1");
+        updated.AgentId = "agent-b";
+        await store.UpsertAsync(updated);
+
+        var loaded = await store.LoadAsync("s1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("agent-b", loaded!.AgentId);
+    }
+
     // ── Hilfsmethoden ────────────────────────────────────────────────────────
 
     private static SessionRecord MakeSession(


### PR DESCRIPTION
## Zusammenfassung
- fange Exceptions bei Tool-Ausführung in ServerChatRunner pro Tool-Call ab (außer OperationCanceledException)
- schreibe Tool-Fehler als reguläre Tool-Result-Message (Fehler: ...), damit ssistant(tool_calls) + 	ool im Verlauf erhalten bleiben
- persistiere und lade AgentId konsistent in SessionStore (Load/Upsert + Legacy-Migration)
- ergänze Tests für Tool-Exception-Flow und AgentId-Persistenz

## Geänderte Dateien
- src/bashGPT.Core/Cli/ServerChatRunner.cs
- src/bashGPT.Core/Storage/SessionStore.cs
- 	ests/bashGPT.Cli.Tests/Cli/ServerChatRunnerTests.cs
- 	ests/bashGPT.Core.Tests/Storage/SessionStoreTests.cs

## Verifikation
- dotnet build src/bashGPT.Core/bashGPT.Core.csproj --no-restore ✅
- dotnet build/test tests/bashGPT.Cli.Tests/... in dieser Umgebung nicht stabil ausführbar (MSBuild bricht bei Projekt-Referenzauflösung ohne Compilerdiagnostik ab)
