### PR TITLE
docs: add community health files for open-source launch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Code of Conduct
+
+## Our Standard
+This project expects respectful, technically constructive collaboration.
+
+Examples of behavior that support a healthy community:
+- Give feedback that is specific, factual, and actionable.
+- Assume good faith while still challenging technical weak spots clearly.
+- Keep discussions focused on the code, design, or documented process.
+- Respect different experience levels and communication styles.
+
+Examples of unacceptable behavior:
+- Personal attacks, harassment, intimidation, or discrimination.
+- Bad-faith arguing, trolling, or deliberately derailing discussions.
+- Publishing private information without explicit permission.
+- Hostile or dismissive behavior that makes collaboration unsafe.
+
+## Enforcement
+Project maintainers may edit, hide, lock, or remove comments, issues, pull requests, or other contributions that violate this code of conduct.
+
+## Reporting
+For conduct concerns, contact the maintainer privately before escalating publicly. For security issues, use the process in [SECURITY.md](SECURITY.md).
+
+## Scope
+This code of conduct applies to repository discussions, issues, pull requests, and other project-managed communication spaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+## Scope
+Contributions are welcome for bug fixes, documentation, tests, tooling, and targeted improvements to the CLI, server UI, agents, and tool system.
+
+## Local Setup
+Prerequisites:
+- .NET 9 SDK
+- Node.js >= 20.19.0 or >= 22.12.0
+- Ollama locally if you want to exercise runtime chat flows beyond build/test
+
+Clone the repository and run:
+
+```bash
+dotnet build -m:1 /nodeReuse:false
+dotnet test -m:1 /nodeReuse:false
+```
+
+Optional web-only validation:
+
+```bash
+cd src/bashGPT.Web
+npm test
+```
+
+## Project Layout
+- `src/bashGPT.Core/`: shared domain logic, configuration, providers, shell, storage
+- `src/bashGPT.Cli/`: CLI entrypoint and command parsing
+- `src/bashGPT.Server/`: local server and embedded browser UI host
+- `tests/`: mirrored test projects by area
+
+## Coding Guidelines
+- C# uses nullable reference types and implicit usings.
+- Use 4 spaces and file-scoped namespaces where appropriate.
+- `PascalCase` for public types and members, `camelCase` for locals and parameters.
+- Keep classes focused by area and avoid broad cross-cutting changes unless required.
+- Prefer ASCII unless a file already clearly uses Unicode.
+
+## Testing Expectations
+- Add or update tests with behavior changes.
+- Prefer the matching test project for the changed area.
+- Keep test names descriptive in the `Method_Condition_Result` style.
+- If a change affects the embedded web frontend, run the relevant `npm` tests or build path.
+
+## Pull Requests
+- Keep PRs scoped to one issue or one coherent change set.
+- Include:
+  - a short summary of the change
+  - the commands you ran for verification
+  - any config, environment, or migration notes
+- Avoid mixing unrelated refactors with user-facing fixes.
+
+## Commit Messages
+Use short conventional-style messages such as:
+- `fix: verhindere plaintext-secret im settings api`
+- `docs: aktualisiere launch-check`
+- `refactor: vereinfache provider factory`
+
+## Security
+Do not open public issues for undisclosed vulnerabilities. Follow the guidance in [SECURITY.md](SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stefan Merkel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ KI-gestützter Shell-Assistent für die Kommandozeile. bashGPT sammelt optional 
 - **Browser-UI**: eingebetteter HTTP-Server mit Chat-Verlauf, Session-Verwaltung und Agent-Auswahl
 - **Agenten**: spezialisierte Chat-Modi (Shell-Agent, Dev-Agent) mit dedizierten Tool-Sets
 - **Tools-Ökosystem**: modulare LLM-Tools für Filesystem, Git, Build, Tests, Web-Fetch und Shell
+- Lizenz: [MIT](LICENSE)
 
 ## Installation
 Voraussetzungen: **.NET 9 SDK** und **Node.js ≥ 20.19.0** (oder ≥ 22.12.0) — benötigt von Vite 7 beim Frontend-Build.
@@ -125,4 +126,9 @@ ls -la
 ```
 
 ## Lizenz
-Noch nicht definiert.
+MIT. Details in [LICENSE](LICENSE).
+
+## Community
+- Contribution Guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Security Policy: [SECURITY.md](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+Please do not report undisclosed vulnerabilities in public issues, discussions, or pull requests.
+
+Preferred channel:
+- GitHub private vulnerability reporting for this repository, if available
+
+If private reporting is not available, contact the maintainer privately first and wait for confirmation before publishing details.
+
+## What to Include
+Please include:
+- a clear description of the issue
+- affected component or file path
+- reproduction steps or proof of concept
+- potential impact
+- suggested mitigation, if you have one
+
+## Response Expectations
+Best effort will be made to:
+- acknowledge reports promptly
+- reproduce and assess the issue
+- communicate whether the report is accepted, needs more detail, or is out of scope
+
+## Scope Notes
+This project is a local CLI and local server UI that can execute tools against the host machine. Reports that affect trust boundaries, secret exposure, command execution, filesystem access, or network access are especially relevant.


### PR DESCRIPTION
## Summary
- add the missing open-source community health files: LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md, and SECURITY.md
- choose and document the MIT license in the repository root and README
- link the new contribution and security guidance from the README so GitHub and external contributors can find them quickly

## Testing
- documentation-only change; no code paths changed

## Issues
- closes #154
