### PR TITLE
docs: add release process and github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a defect or behavioral regression
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+Describe the bug clearly and concretely.
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+What should have happened?
+
+## Actual Behavior
+What happened instead?
+
+## Environment
+- OS:
+- .NET SDK:
+- Node.js:
+- Ollama version, if relevant:
+
+## Logs / Screenshots
+Add relevant output, stack traces, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Propose a user-facing improvement or new capability
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+What problem should this solve?
+
+## Proposed Change
+Describe the desired behavior or workflow.
+
+## Alternatives Considered
+List any simpler or competing approaches.
+
+## Additional Context
+Add examples, screenshots, or constraints if helpful.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+- describe the change in 1-3 bullets
+
+## Testing
+- list the commands you ran
+- include notable outcomes or explain why a step was skipped
+
+## Notes
+- mention config, migration, release, or documentation implications if relevant
+
+## Related Issues
+- link or close related issues here

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ dotnet test --collect:"XPlat Code Coverage"
 Reproduzierbarer Open-Source-Launch-Check:
 - [docs/testing/open-source-launch-checklist.md](docs/testing/open-source-launch-checklist.md)
 
+Release- und Public-Launch-Runbook:
+- [docs/release/public-launch-runbook.md](docs/release/public-launch-runbook.md)
+
 ## Beispiele (Output-Format)
 bashGPT erwartet, dass Shell-Befehle in Code-Blöcken stehen. Beispielantwort:
 ```bash

--- a/docs/release/public-launch-runbook.md
+++ b/docs/release/public-launch-runbook.md
@@ -1,0 +1,77 @@
+# Public Launch Runbook
+
+Last updated: March 16, 2026
+
+## Goal
+Provide a predictable maintainer workflow for making the repository public and publishing the first release.
+
+## Suggested First Release
+- Tag: `v0.1.0`
+- Scope: first public open-source release of the Ollama-only codebase
+
+## Pre-Launch Checklist
+- Community health files exist:
+  - `LICENSE`
+  - `CONTRIBUTING.md`
+  - `CODE_OF_CONDUCT.md`
+  - `SECURITY.md`
+- README reflects the current CLI, server, and Ollama-only setup
+- Open-source launch check has passed:
+  - `dotnet build -m:1 /nodeReuse:false`
+  - `dotnet test -m:1 /nodeReuse:false`
+- Remaining launch blockers are explicitly resolved or accepted
+- Repository description, topics, and homepage are set in GitHub
+
+## Release Candidate Flow
+1. Merge all launch-blocking issues into `main`.
+2. Run the full build and test check from a clean checkout.
+3. Review the diff since the last internal milestone and summarize user-visible changes.
+4. Create tag `v0.1.0` from the exact release commit.
+5. Draft GitHub release notes from the merged PRs and milestone issues.
+
+## Recommended Release Notes Structure
+- Highlights
+- Breaking or notable behavior changes
+- Setup requirements
+- Known limitations
+
+## Public Toggle Checklist
+Before switching the repository to public:
+- Confirm repository description is accurate
+- Add or verify topics relevant to `dotnet`, `cli`, `ollama`, `agent`, `tool-calling`
+- Verify Actions permissions and default branch protections
+- Verify security reporting path in `SECURITY.md`
+- Verify issue and PR templates are active
+
+## Go-Live Day Steps
+1. Pull latest `main`.
+2. Re-run:
+   ```bash
+   dotnet build -m:1 /nodeReuse:false
+   dotnet test -m:1 /nodeReuse:false
+   ```
+3. Create and push release tag:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+4. Publish the GitHub release with curated notes.
+5. Switch repository visibility to public.
+6. Verify public-facing pages:
+   - README renders correctly
+   - license is detected by GitHub
+   - issue and PR templates are available
+   - release page is visible
+
+## Go / No-Go Criteria
+- Go:
+  - build and test are green on the release commit
+  - repo metadata and community files are complete
+  - first release tag and notes are prepared
+- No-Go:
+  - unresolved launch blocker issues remain
+  - build/test only works with undocumented local fixes
+  - public-facing docs contradict the shipped behavior
+
+## Notes
+- Repository metadata like description, topics, homepage, and visibility cannot be enforced from this repository alone; they must be set in GitHub UI or via `gh repo edit`.


### PR DESCRIPTION
## Summary
- add default GitHub issue templates for bug reports and feature requests
- add a pull request template for consistent review and release information
- document a maintainer-facing public launch and release runbook and link it from the README

## Testing
- documentation and GitHub template changes only

## Issues
- closes #152
