### PR TITLE
build: pinne toolchain fuer release-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '9.0.301'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           cache: 'npm'
           cache-dependency-path: src/bashGPT.Web/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ KI-gestützter Shell-Assistent für die Kommandozeile. bashGPT sammelt optional 
 - Lizenz: [MIT](LICENSE)
 
 ## Installation
-Voraussetzungen: **.NET 9 SDK** und **Node.js ≥ 20.19.0** (oder ≥ 22.12.0) — benötigt von Vite 7 beim Frontend-Build.
+Voraussetzungen für reproduzierbare Release-Checks: **.NET SDK 9.0.301** und **Node.js 20.19.0**.
+
+Für den Frontend-Build sind zusätzlich kompatibel: **Node.js ≥ 20.19.0** oder **≥ 22.12.0** — benötigt von Vite 7.
 
 Weitere lokale Voraussetzungen je nach Nutzung:
 - `git` für Git-Tools und Git-Kontext (`git --version`)

--- a/docs/testing/open-source-launch-checklist.md
+++ b/docs/testing/open-source-launch-checklist.md
@@ -6,8 +6,8 @@ Last validated: March 16, 2026
 Provide a minimal, reproducible launch check for an external developer on a clean machine.
 
 ## Prerequisites
-- .NET 9 SDK
-- Node.js >= 20.19.0 or >= 22.12.0
+- .NET SDK 9.0.301 (`global.json`)
+- Node.js 20.19.0 (same version as CI release checks)
 - Ollama available locally if chat/server runtime should be exercised beyond build/test
 
 ## Reproducible Check
@@ -49,6 +49,7 @@ npm test
   - `dotnet test -m:1 /nodeReuse:false`: passed
   - `src/bashGPT.Web` build path is reproducible via stamp-based `npm ci`
   - README matches the Ollama-only setup and current server flags
+  - Release baseline is pinned to `.NET SDK 9.0.301` and `Node.js 20.19.0`
 
 ## Known Launch Blockers Outside This Check
 - License and community-health files are still tracked separately in `#154`.

--- a/docs/testing/runbook-server-ui.md
+++ b/docs/testing/runbook-server-ui.md
@@ -13,8 +13,8 @@ ein `FakePromptHandler`-Stub injiziert wird.
 
 ### Voraussetzungen
 
-- .NET SDK 9.0
-- Node.js 20+ (für Frontend-Build, der dem .NET-Build vorgelagert ist)
+- .NET SDK 9.0.301 (`global.json`)
+- Node.js 20.19.0 für denselben Frontend-Build-Pfad wie in CI
 
 ### Alle Tests ausführen
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.301",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- pin the repository .NET SDK via global.json
- pin CI to the same .NET and Node.js versions used for release checks
- align launch and test documentation with the explicit toolchain baseline

## Testing
- dotnet --version
- dotnet build -m:1 /nodeReuse:false

Closes #159