### PR TITLE
release: ergänze versions- und build-metadaten

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.1.0</Version>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
+    <RepositoryUrl>https://github.com/slekrem/bashGPT</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    <InformationalVersion Condition="'$(SourceRevisionId)' == ''">$(Version)</InformationalVersion>
+    <InformationalVersion Condition="'$(SourceRevisionId)' != ''">$(Version)+$(SourceRevisionId)</InformationalVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>RepositoryUrl</_Parameter1>
+      <_Parameter2>$(RepositoryUrl)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Weitere lokale Voraussetzungen je nach Nutzung:
 - `ollama` für lokale Modellaufrufe im CLI- und Server-Modus (`ollama --version`, danach `ollama serve`)
 - `npm` für den Web-Build sowie den `build_run`-/`test_run`-Runner `npm` (`npm --version`)
 - `pytest` nur falls du den `test_run`-Runner `pytest` verwenden willst (`pytest --version`)
+- Version prüfen: CLI über `dotnet run --project src/bashGPT.Cli -- --version`, Server über `GET /api/version`
 
 ```bash
 # Repo klonen, dann bauen (npm install + npm run build laufen automatisch)

--- a/docs/release/public-launch-runbook.md
+++ b/docs/release/public-launch-runbook.md
@@ -25,9 +25,13 @@ Provide a predictable maintainer workflow for making the repository public and p
 ## Release Candidate Flow
 1. Merge all launch-blocking issues into `main`.
 2. Run the full build and test check from a clean checkout.
-3. Review the diff since the last internal milestone and summarize user-visible changes.
-4. Create tag `v0.1.0` from the exact release commit.
-5. Draft GitHub release notes from the merged PRs and milestone issues.
+3. Verify artifact identity:
+   - `dotnet run --project src/bashGPT.Cli -- --version`
+   - start the server and check `GET /api/version`
+   - both should report the intended release version/tag
+4. Review the diff since the last internal milestone and summarize user-visible changes.
+5. Create tag `v0.1.0` from the exact release commit.
+6. Draft GitHub release notes from the merged PRs and milestone issues.
 
 ## Recommended Release Notes Structure
 - Highlights

--- a/src/bashGPT.Cli/Program.cs
+++ b/src/bashGPT.Cli/Program.cs
@@ -3,6 +3,16 @@ using BashGPT;
 using BashGPT.Cli;
 using BashGPT.Configuration;
 using BashGPT.Shell;
+using BashGPT.Versioning;
+
+if (args is ["--version"])
+{
+    var info = AppVersion.ForAssembly(typeof(Program).Assembly);
+    Console.WriteLine($"{info.Application} {info.InformationalVersion}");
+    if (!string.IsNullOrWhiteSpace(info.RepositoryUrl))
+        Console.WriteLine(info.RepositoryUrl);
+    return 0;
+}
 
 var configService = new ConfigurationService();
 var contextCollector = new ShellContextCollector();

--- a/src/bashGPT.Core/Versioning/AppVersionInfo.cs
+++ b/src/bashGPT.Core/Versioning/AppVersionInfo.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace BashGPT.Versioning;
+
+public sealed record AppVersionInfo(
+    string Application,
+    string Version,
+    string InformationalVersion,
+    string? RepositoryUrl);
+
+public static class AppVersion
+{
+    public static AppVersionInfo ForAssembly(Assembly assembly)
+    {
+        var name = assembly.GetName();
+        var application = name.Name ?? "bashGPT";
+        var version = name.Version?.ToString() ?? "0.0.0.0";
+        var informationalVersion =
+            assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? version;
+        var repositoryUrl = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "RepositoryUrl")?.Value;
+
+        return new AppVersionInfo(application, version, informationalVersion, repositoryUrl);
+    }
+}

--- a/src/bashGPT.Server/Server/ServerHost.cs
+++ b/src/bashGPT.Server/Server/ServerHost.cs
@@ -156,6 +156,9 @@ public class ServerHost
             if (req.HttpMethod == "GET"  && path == "/api/context")
             { await _contextHandler.HandleAsync(ctx.Response, ct); return; }
 
+            if (req.HttpMethod == "GET"  && path == "/api/version")
+            { await new VersionApiHandler().HandleAsync(ctx.Response, ct); return; }
+
             if (path.StartsWith("/api/settings", StringComparison.Ordinal))
             { await _settingsHandler.HandleAsync(ctx, ct); return; }
 

--- a/src/bashGPT.Server/Server/VersionApiHandler.cs
+++ b/src/bashGPT.Server/Server/VersionApiHandler.cs
@@ -1,0 +1,19 @@
+using System.Net;
+using BashGPT.Versioning;
+
+namespace BashGPT.Server;
+
+internal sealed class VersionApiHandler
+{
+    public async Task HandleAsync(HttpListenerResponse response, CancellationToken ct)
+    {
+        var info = AppVersion.ForAssembly(typeof(ServerHost).Assembly);
+        await ApiResponse.WriteJsonAsync(response, new
+        {
+            application = info.Application,
+            version = info.Version,
+            informationalVersion = info.InformationalVersion,
+            repositoryUrl = info.RepositoryUrl,
+        });
+    }
+}

--- a/tests/bashGPT.Server.Tests/Server/ServerHostTests.cs
+++ b/tests/bashGPT.Server.Tests/Server/ServerHostTests.cs
@@ -86,6 +86,20 @@ public sealed class ServerHostTests : IAsyncLifetime
         Assert.Contains("javascript", response.Content.Headers.ContentType?.MediaType);
     }
 
+    [Fact]
+    public async Task Get_Version_ReturnsVersionMetadata()
+    {
+        var response = await _client.GetAsync("/api/version");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("bashGPT.Server", json.GetProperty("application").GetString());
+        Assert.Equal("0.1.0.0", json.GetProperty("version").GetString());
+        Assert.StartsWith("0.1.0", json.GetProperty("informationalVersion").GetString(), StringComparison.Ordinal);
+        Assert.Equal("https://github.com/slekrem/bashGPT", json.GetProperty("repositoryUrl").GetString());
+    }
+
     // ── GET /api/history ────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- zentralisiere Versions- und Repository-Metadaten in einer gemeinsamen Build-Konfiguration
- ergänze sichtbare Versionspfade für CLI und Server über `--version` und `/api/version`
- dokumentiere die Versionsprüfung im README und im Public-Launch-Runbook

## Testing
- dotnet test tests/bashGPT.Server.Tests/bashGPT.Server.Tests.csproj --filter ServerHostTests -m:1 /nodeReuse:false
- dotnet build src/bashGPT.Cli/bashGPT.Cli.csproj -m:1 /nodeReuse:false
- dotnet src/bashGPT.Cli/bin/Debug/net9.0/bashGPT.Cli.dll --version

Closes #158