### PR TITLE
build: ersetze system-commandline preview durch stable

### DIFF
--- a/docs/release/public-launch-runbook.md
+++ b/docs/release/public-launch-runbook.md
@@ -79,5 +79,5 @@ Before switching the repository to public:
   - public-facing docs contradict the shipped behavior
 
 ## Notes
-- `System.CommandLine` is pinned to the stable `2.0.0` release for both host projects. No preview-only APIs are used in the current CLI or server entry points.
+- `System.CommandLine` is pinned to the stable `2.0.2` release for both host projects. No preview-only APIs are used in the current CLI or server entry points.
 - Repository metadata like description, topics, homepage, and visibility cannot be enforced from this repository alone; they must be set in GitHub UI or via `gh repo edit`.

--- a/src/bashGPT.Cli/bashGPT.Cli.csproj
+++ b/src/bashGPT.Cli/bashGPT.Cli.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/bashGPT.Server/bashGPT.Server.csproj
+++ b/src/bashGPT.Server/bashGPT.Server.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- ersetze die Preview-Abhängigkeit auf `System.CommandLine` in CLI und Server durch die stabile Version `2.0.2`
- halte die Release-Entscheidung und den verbleibenden Scope im Public-Launch-Runbook fest
- verifiziere, dass beide Host-Projekte mit der stabilen Abhängigkeit sauber bauen

## Testing
- dotnet build src/bashGPT.Cli/bashGPT.Cli.csproj -m:1 /nodeReuse:false
- dotnet build src/bashGPT.Server/bashGPT.Server.csproj -m:1 /nodeReuse:false

Closes #160