### PR TITLE
security: sanitisiere server-fehlermeldungen

### DIFF
--- a/src/bashGPT.Server/Server/ApiErrors.cs
+++ b/src/bashGPT.Server/Server/ApiErrors.cs
@@ -1,0 +1,7 @@
+namespace BashGPT.Server;
+
+internal static class ApiErrors
+{
+    internal const string GenericServerError = "Interner Serverfehler.";
+    internal const string GenericProviderError = "Verbindungstest fehlgeschlagen.";
+}

--- a/src/bashGPT.Server/Server/ServerHost.cs
+++ b/src/bashGPT.Server/Server/ServerHost.cs
@@ -184,7 +184,8 @@ public class ServerHost
         }
         catch (Exception ex)
         {
-            await ApiResponse.WriteJsonAsync(ctx.Response, new { error = ex.Message }, statusCode: 500);
+            Console.Error.WriteLine($"[server] Unbehandelter Request-Fehler: {ex}");
+            await ApiResponse.WriteJsonAsync(ctx.Response, new { error = ApiErrors.GenericServerError }, statusCode: 500);
         }
     }
 

--- a/src/bashGPT.Server/Server/SettingsApiHandler.cs
+++ b/src/bashGPT.Server/Server/SettingsApiHandler.cs
@@ -113,7 +113,8 @@ internal sealed class SettingsApiHandler(ConfigurationService? configService, Se
         }
         catch (LlmProviderException ex)
         {
-            await ApiResponse.WriteJsonAsync(response, new { ok = false, error = ex.Message });
+            Console.Error.WriteLine($"[server] Provider-Verbindungstest fehlgeschlagen: {ex}");
+            await ApiResponse.WriteJsonAsync(response, new { ok = false, error = ApiErrors.GenericProviderError });
         }
     }
 

--- a/src/bashGPT.Server/Server/StreamingChatApiHandler.cs
+++ b/src/bashGPT.Server/Server/StreamingChatApiHandler.cs
@@ -244,8 +244,9 @@ internal sealed class StreamingChatApiHandler(
         {
             try
             {
+                Console.Error.WriteLine($"[server] Streaming-Request fehlgeschlagen: {ex}");
                 var errJson = JsonSerializer.Serialize(
-                    new { choices = new[] { new { delta = new { content = "", bashgpt = new { @event = "error", data = new { message = ex.Message } } } } } },
+                    new { choices = new[] { new { delta = new { content = "", bashgpt = new { @event = "error", data = new { message = ApiErrors.GenericServerError } } } } } },
                     JsonDefaults.Options);
                 ApiResponse.WriteSseEvent(stream, errJson);
                 ApiResponse.WriteSseEvent(stream, "[DONE]");

--- a/tests/bashGPT.Server.Tests/Server/ServerHostSettingsTests.cs
+++ b/tests/bashGPT.Server.Tests/Server/ServerHostSettingsTests.cs
@@ -317,6 +317,24 @@ public sealed class ServerHostSettingsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Post_SettingsTest_Failure_ReturnsSanitizedError()
+    {
+        var config = await _configService.LoadAsync();
+        config.Ollama.BaseUrl = "http://127.0.0.1:1";
+        await _configService.SaveAsync(config);
+
+        var response = await _client.PostAsync("/api/settings/test", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var raw = await response.Content.ReadAsStringAsync();
+        var json = JsonSerializer.Deserialize<JsonElement>(raw);
+        Assert.False(json.GetProperty("ok").GetBoolean());
+        Assert.Equal("Verbindungstest fehlgeschlagen.", json.GetProperty("error").GetString());
+        Assert.DoesNotContain("127.0.0.1:1", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Put_Settings_WithoutConfigService_Returns503()
     {
         var port = GetFreePort();

--- a/tests/bashGPT.Server.Tests/Server/ServerHostTests.cs
+++ b/tests/bashGPT.Server.Tests/Server/ServerHostTests.cs
@@ -217,7 +217,8 @@ public sealed class ServerHostTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
         var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.True(json.TryGetProperty("error", out _));
+        Assert.Equal("Interner Serverfehler.", json.GetProperty("error").GetString());
+        Assert.DoesNotContain("Simulierter Fehler", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -257,6 +258,28 @@ public sealed class ServerHostTests : IAsyncLifetime
         var ssePayload = await streamResponse.Content.ReadAsStringAsync();
         Assert.Contains("\"finalStatus\":\"user_cancelled\"", ssePayload);
         Assert.Contains("[DONE]", ssePayload);
+    }
+
+    [Fact]
+    public async Task Post_ChatStream_HandlerThrows_ReturnsSanitizedErrorEvent()
+    {
+        _handler.NextException = new InvalidOperationException("Vertrauliches Streaming-Detail");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/chat/stream")
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(new { prompt = "Bitte streamen" }),
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+        var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        var ssePayload = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Interner Serverfehler.", ssePayload, StringComparison.Ordinal);
+        Assert.DoesNotContain("Vertrauliches Streaming-Detail", ssePayload, StringComparison.Ordinal);
+        Assert.Contains("[DONE]", ssePayload, StringComparison.Ordinal);
     }
 
     // ── 404 ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- ersetze rohe Exception-Messages in JSON- und SSE-Responses durch generische, client-sichere Fehlertexte
- logge die detaillierten Serverfehler weiterhin serverseitig zur Diagnose
- sichere die Sanitization mit Integrationstests fuer normalen Chat, Streaming-Chat und den Settings-Verbindungstest ab

## Testing
- dotnet test tests/bashGPT.Server.Tests/bashGPT.Server.Tests.csproj --filter "ServerHostTests|ServerHostSettingsTests" -m:1 /nodeReuse:false

Closes #176