### PR TITLE
api: entferne tote server-settings aus dem web-vertrag

### DIFF
--- a/src/bashGPT.Server/Server/ServerHost.cs
+++ b/src/bashGPT.Server/Server/ServerHost.cs
@@ -45,7 +45,7 @@ public class ServerHost
         _state                = new ServerState();
         _legacyHistory        = new LegacyHistory();
         _contextHandler       = new ContextApiHandler();
-        _settingsHandler      = new SettingsApiHandler(configService, _state);
+        _settingsHandler      = new SettingsApiHandler(configService);
         _chatHandler          = new ChatApiHandler(handler, _legacyHistory, _toolSelectionPolicy, sessionStore, toolRegistry, agentRegistry);
         _streamingChatHandler = new StreamingChatApiHandler(handler, _legacyHistory, _runningChats, _toolSelectionPolicy, sessionStore, toolRegistry, agentRegistry);
         _chatCancelHandler    = new ChatCancelApiHandler(_runningChats);

--- a/src/bashGPT.Server/Server/SettingsApiHandler.cs
+++ b/src/bashGPT.Server/Server/SettingsApiHandler.cs
@@ -8,7 +8,7 @@ using BashGPT.Providers;
 
 namespace BashGPT.Server;
 
-internal sealed class SettingsApiHandler(ConfigurationService? configService, ServerState state)
+internal sealed class SettingsApiHandler(ConfigurationService? configService)
 {
     public async Task HandleAsync(HttpListenerContext ctx, CancellationToken ct)
     {
@@ -42,8 +42,6 @@ internal sealed class SettingsApiHandler(ConfigurationService? configService, Se
             model             = config.Ollama.Model,
             contextWindowTokens = (int?)null,
             ollamaHost        = config.Ollama.BaseUrl,
-            execMode          = ExecModeConverter.ToString(state.ExecMode),
-            forceTools        = state.ForceTools,
             ollama            = new
             {
                 model = config.Ollama.Model,
@@ -79,16 +77,6 @@ internal sealed class SettingsApiHandler(ConfigurationService? configService, Se
 
         if (body.Model is not null) config.Ollama.Model = body.Model;
         if (body.OllamaHost is not null) config.Ollama.BaseUrl = body.OllamaHost;
-        if (body.ExecMode is not null && ExecModeConverter.Parse(body.ExecMode) is { } mode)
-        {
-            state.ExecMode = mode;
-            config.DefaultExecMode = mode;
-        }
-        if (body.ForceTools is bool ft)
-        {
-            state.ForceTools = ft;
-            config.DefaultForceTools = ft;
-        }
         await configService.SaveAsync(config);
         await ApiResponse.WriteJsonAsync(ctx.Response, new { ok = true });
     }
@@ -129,7 +117,7 @@ internal sealed class SettingsApiHandler(ConfigurationService? configService, Se
 
     private sealed record SettingsRequest(
         string? Provider, string? Model,
-        string? OllamaHost, string? ExecMode, bool? ForceTools,
+        string? OllamaHost,
         ProviderConfigRequest? Ollama);
 
     private sealed record ProviderConfigRequest(

--- a/src/bashGPT.Web/src/types.ts
+++ b/src/bashGPT.Web/src/types.ts
@@ -31,7 +31,6 @@ export interface HistoryMessage {
   content: string
 }
 
-export type ExecMode = 'ask' | 'dry-run' | 'auto-exec' | 'no-exec'
 export type ProviderName = 'ollama'
 
 export interface Session {
@@ -51,8 +50,6 @@ export interface Settings {
   model: string
   contextWindowTokens?: number
   ollamaHost?: string
-  execMode: ExecMode
-  forceTools: boolean
   ollama: OllamaSettings
 }
 

--- a/tests/bashGPT.Server.Tests/Server/ServerHostSettingsTests.cs
+++ b/tests/bashGPT.Server.Tests/Server/ServerHostSettingsTests.cs
@@ -107,8 +107,8 @@ public sealed class ServerHostSettingsTests : IAsyncLifetime
         Assert.True(json.TryGetProperty("provider", out var provider));
         Assert.True(json.TryGetProperty("model", out _));
         Assert.True(json.TryGetProperty("ollamaHost", out _));
-        Assert.True(json.TryGetProperty("execMode", out _));
-        Assert.True(json.TryGetProperty("forceTools", out _));
+        Assert.False(json.TryGetProperty("execMode", out _));
+        Assert.False(json.TryGetProperty("forceTools", out _));
 
         // Standardprovider ist Ollama
         Assert.Equal("ollama", provider.GetString());
@@ -191,110 +191,6 @@ public sealed class ServerHostSettingsTests : IAsyncLifetime
 
         var config = await _configService.LoadAsync();
         Assert.Equal("ollama-updated", config.Ollama.Model);
-    }
-
-    [Fact]
-    public async Task Put_Settings_UpdatesExecMode_InMemory()
-    {
-        // ExecMode auf auto-exec setzen
-        var body = JsonSerializer.Serialize(new { execMode = "auto-exec" });
-        var putResponse = await _client.PutAsync("/api/settings",
-            new StringContent(body, Encoding.UTF8, "application/json"));
-        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
-
-        // GET prüft, ob der In-Memory-Wert aktualisiert wurde
-        var getResponse = await _client.GetFromJsonAsync<JsonElement>("/api/settings");
-        Assert.Equal("auto-exec", getResponse.GetProperty("execMode").GetString());
-    }
-
-    // ── Persistenz über Neustart ─────────────────────────────────────────────
-
-    [Fact]
-    public async Task PutSettings_ExecMode_PersistsAcrossServerRestart()
-    {
-        // ExecMode auf dry-run setzen
-        var body = System.Text.Json.JsonSerializer.Serialize(new { execMode = "dry-run" });
-        var putResponse = await _client.PutAsync("/api/settings",
-            new StringContent(body, Encoding.UTF8, "application/json"));
-        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
-
-        // Config-Datei enthält DefaultExecMode
-        var config = await _configService.LoadAsync();
-        Assert.Equal(BashGPT.Shell.ExecutionMode.DryRun, config.DefaultExecMode);
-
-        // Neuen Server mit derselben Config-Datei starten (ohne CLI-Override)
-        var port2 = GetFreePort();
-        var server2 = new ServerHost(_handler, _configService);
-        using var cts2 = new CancellationTokenSource();
-        var options2 = new ServerOptions(port2, true, null, null, false);
-        var task2 = server2.RunAsync(options2, cts2.Token);
-        var url2 = $"http://127.0.0.1:{port2}";
-        await WaitForServerAsync(url2);
-
-        using var client2 = new HttpClient { BaseAddress = new Uri(url2) };
-        var getResponse = await client2.GetFromJsonAsync<System.Text.Json.JsonElement>("/api/settings");
-        Assert.Equal("dry-run", getResponse.GetProperty("execMode").GetString());
-
-        await cts2.CancelAsync();
-        try { using var probe = new HttpClient(); await probe.GetAsync($"{url2}/"); } catch { }
-        try { await task2.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
-    }
-
-    [Fact]
-    public async Task PutSettings_ForceTools_PersistsAcrossServerRestart()
-    {
-        // ForceTools auf true setzen
-        var body = System.Text.Json.JsonSerializer.Serialize(new { forceTools = true });
-        var putResponse = await _client.PutAsync("/api/settings",
-            new StringContent(body, Encoding.UTF8, "application/json"));
-        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
-
-        // Config-Datei enthält DefaultForceTools
-        var config = await _configService.LoadAsync();
-        Assert.True(config.DefaultForceTools);
-
-        // Neuen Server mit derselben Config-Datei starten (ohne CLI-Override)
-        var port2 = GetFreePort();
-        var server2 = new ServerHost(_handler, _configService);
-        using var cts2 = new CancellationTokenSource();
-        var options2 = new ServerOptions(port2, true, null, null, false);
-        var task2 = server2.RunAsync(options2, cts2.Token);
-        var url2 = $"http://127.0.0.1:{port2}";
-        await WaitForServerAsync(url2);
-
-        using var client2 = new HttpClient { BaseAddress = new Uri(url2) };
-        var getResponse = await client2.GetFromJsonAsync<System.Text.Json.JsonElement>("/api/settings");
-        Assert.True(getResponse.GetProperty("forceTools").GetBoolean());
-
-        await cts2.CancelAsync();
-        try { using var probe = new HttpClient(); await probe.GetAsync($"{url2}/"); } catch { }
-        try { await task2.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
-    }
-
-    [Fact]
-    public async Task ServerInit_LoadsDefaultExecModeFromConfig()
-    {
-        // Config mit DefaultExecMode=AutoExec speichern
-        var config = await _configService.LoadAsync();
-        config.DefaultExecMode = BashGPT.Shell.ExecutionMode.AutoExec;
-        await _configService.SaveAsync(config);
-
-        // Neuen Server starten ohne CLI-ExecMode-Override (null)
-        var port2 = GetFreePort();
-        var server2 = new ServerHost(_handler, _configService);
-        using var cts2 = new CancellationTokenSource();
-        var options2 = new ServerOptions(port2, true, null, null, false);
-        var task2 = server2.RunAsync(options2, cts2.Token);
-        var url2 = $"http://127.0.0.1:{port2}";
-        await WaitForServerAsync(url2);
-
-        using var client2 = new HttpClient { BaseAddress = new Uri(url2) };
-        var getResponse = await client2.GetFromJsonAsync<System.Text.Json.JsonElement>("/api/settings");
-        Assert.Equal("auto-exec", getResponse.GetProperty("execMode").GetString());
-
-        await cts2.CancelAsync();
-        try { using var probe = new HttpClient(); await probe.GetAsync($"{url2}/"); } catch { }
-        try { await task2.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
     }
 
     // ── POST /api/settings/test ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- entferne `execMode` und `forceTools` aus dem oeffentlichen Server-Settings-Vertrag
- bereinige den Web-Typ `Settings` auf den tatsaechlich genutzten Ollama-only-Scope
- loesche die zugehoerigen Server-Tests fuer die nicht mehr exponierten Felder und sichere den reduzierten Vertrag ab

## Testing
- dotnet test tests/bashGPT.Server.Tests/bashGPT.Server.Tests.csproj --filter ServerHostSettingsTests -m:1 /nodeReuse:false

Closes #175