### PR TITLE
fix: update dompurify to patched version

### DIFF
--- a/src/bashGPT.Web/package-lock.json
+++ b/src/bashGPT.Web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bashgpt-web",
       "version": "0.0.0",
       "dependencies": {
-        "dompurify": "^3.2.7",
+        "dompurify": "^3.3.2",
         "highlight.js": "^11.11.1",
         "lit": "^3.3.1",
         "marked": "^17.0.3"
@@ -1034,10 +1034,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -1163,7 +1166,6 @@
       "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -1288,7 +1290,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1472,7 +1473,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/bashGPT.Web/package.json
+++ b/src/bashGPT.Web/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "dompurify": "^3.2.7",
+    "dompurify": "^3.3.2",
     "highlight.js": "^11.11.1",
     "lit": "^3.3.1",
     "marked": "^17.0.3"


### PR DESCRIPTION
## Summary
- bump `dompurify` from the vulnerable 3.3.1 line to the patched 3.3.2 release
- refresh the frontend lockfile accordingly
- address the open Dependabot alert for CVE-2026-0540 / GHSA-v2wj-7wpq-c8vv

## Testing
- `npm.cmd run test`
- `npm.cmd run build`

## Notes
- the current alert is GitHub Dependabot alert #1 for `src/bashGPT.Web/package-lock.json`