### PR TITLE
feat(web): translate frontend to English

### DIFF
--- a/src/06_app/bashGPT.Web/index.html
+++ b/src/06_app/bashGPT.Web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/06_app/bashGPT.Web/src/components/chat-app.ts
+++ b/src/06_app/bashGPT.Web/src/components/chat-app.ts
@@ -55,7 +55,7 @@ export class ChatApp extends LitElement {
       }
       chatView.loadSnapshot?.(
         data.messages,
-        'Archivierte Session – Nachricht senden, um fortzufahren',
+        'Archived session – send a message to continue',
         data.enabledTools,
       )
       chatView.scrollToBottom?.()
@@ -141,7 +141,7 @@ export class ChatApp extends LitElement {
     if (!activeId) return
     if (!this._sessions.some(s => s.id === activeId)) {
       const now = new Date().toISOString()
-      this._sessions = [{ id: activeId, title: 'Aktueller Chat', createdAt: now, updatedAt: now }, ...this._sessions]
+      this._sessions = [{ id: activeId, title: 'Current Chat', createdAt: now, updatedAt: now }, ...this._sessions]
     }
     if (this._sm.useFallback) this._activeSessionId = LIVE_SESSION_ID
   }
@@ -169,7 +169,7 @@ export class ChatApp extends LitElement {
           <button
             class="hamburger"
             @click=${() => { this._mobileMenuOpen = !this._mobileMenuOpen }}
-            aria-label="Menü"
+            aria-label="Menu"
           >☰</button>
         </div>
       </header>

--- a/src/06_app/bashGPT.Web/src/components/chat-view.ts
+++ b/src/06_app/bashGPT.Web/src/components/chat-view.ts
@@ -18,15 +18,15 @@ interface Message {
 
 @customElement('bashgpt-chat-view')
 export class ChatView extends LitElement {
-  /** Wird von außen gesetzt (Dashboard-Prompt) – löst sofortigen Send aus */
+  /** Set externally (dashboard prompt) – triggers immediate send */
   @property() pendingPrompt = ''
-  /** Gesetzt wenn die View aktiv (sichtbar) ist – lädt History wenn leer */
+  /** Set when the view is active (visible) – loads history if empty */
   @property({ type: Boolean }) active = false
-  /** One-shot Hook: wird vor dem ersten sendChat() der Session aufgerufen */
+  /** One-shot hook: called before the first sendChat() of the session */
   @property({ attribute: false }) beforeSend?: () => Promise<void>
-  /** Session-ID für server-seitige Persistenz (optional) */
+  /** Session ID for server-side persistence (optional) */
   @property() sessionId = ''
-  /** Agent-ID für agenten-spezifischen System-Prompt und Tools (optional) */
+  /** Agent ID for agent-specific system prompt and tools (optional) */
   @property() agentId = ''
 
   // ── Grouped reactive state (3 @state instead of 13) ───────────────────────
@@ -322,8 +322,8 @@ export class ChatView extends LitElement {
 
   updated(changed: Map<string, unknown>) {
     if (changed.has('pendingPrompt') && this.pendingPrompt) {
-      // Verhindert Duplikate beim gleichen String, erlaubt aber erneutes Ausführen
-      // nachdem pendingPrompt im Parent kurz auf '' zurückgesetzt wurde.
+      // Prevents duplicates for the same string, but allows re-execution
+      // after pendingPrompt is briefly reset to '' in the parent.
       if (this.pendingPrompt !== this._lastHandledPendingPrompt) {
         this._lastHandledPendingPrompt = this.pendingPrompt
         this._sendPrompt(this.pendingPrompt)
@@ -331,20 +331,20 @@ export class ChatView extends LitElement {
     } else if (changed.has('pendingPrompt') && !this.pendingPrompt) {
       this._lastHandledPendingPrompt = ''
     }
-    // History nachladen, wenn die View aktiv wird und noch keine Nachrichten vorhanden sind
+    // Reload history when the view becomes active and no messages are present yet
     if (changed.has('active') && this.active && this._chat.messages.length === 0) {
       this._loadHistory()
     }
-    // Agenten-Daten neu laden, wenn sich der Agent ändert und das Panel offen ist
+    // Reload agent data when the agent changes and the info panel is open
     if (changed.has('agentId') && this._panels.infoOpen) {
       void this._loadInfoPanel()
     }
   }
 
-  /** Öffentlich: Snapshot-Messages laden (für archivierte Sessions) */
+  /** Public: load snapshot messages (for archived sessions) */
   loadSnapshot(messages: SnapshotMessage[], hint?: string, enabledTools?: string[]) {
-    // Laufendes _loadHistory() abbrechen – sonst würde der Server-Stand
-    // (text-only, ohne commands) die soeben gesetzten Daten überschreiben.
+    // Cancel running _loadHistory() – otherwise server state
+    // (text-only, without commands) would overwrite the just-set data.
     this._historyLoadSeq++
     const newMessages = messages
       .filter(m => (m.role === 'user' || m.role === 'assistant') && m.content.trim() !== '')
@@ -366,7 +366,7 @@ export class ChatView extends LitElement {
     this._toolPickerOpen = false
   }
 
-  /** Öffentlich: Chat direkt zur letzten Nachricht scrollen */
+  /** Public: scroll chat to the latest message */
   scrollToBottom() {
     void this.updateComplete.then(() => {
       const chatEl = this.shadowRoot?.querySelector('#chat') as HTMLElement | null
@@ -375,7 +375,7 @@ export class ChatView extends LitElement {
     })
   }
 
-  /** Öffentlich: Aktuelle Messages als Snapshot auslesen */
+  /** Public: read current messages as a snapshot */
   getSnapshot(): SnapshotMessage[] {
     return this._chat.messages.map(m => ({
       role: m.role,
@@ -385,7 +385,7 @@ export class ChatView extends LitElement {
     }))
   }
 
-  /** Öffentlich: Session zurücksetzen */
+  /** Public: reset session */
   async reset() {
     try {
       // Only use the legacy history reset when no explicit session is active.
@@ -396,7 +396,7 @@ export class ChatView extends LitElement {
         ...this._chat,
         messages:   [],
         tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        statusText: 'Verlauf gelöscht',
+        statusText: 'History cleared',
         statusError: false,
       }
       this._enabledTools = []
@@ -405,7 +405,7 @@ export class ChatView extends LitElement {
     } catch (e) {
       this._chat = {
         ...this._chat,
-        statusText:  `Fehler: ${e instanceof Error ? e.message : String(e)}`,
+        statusText:  `Error: ${e instanceof Error ? e.message : String(e)}`,
         statusError: true,
       }
     }
@@ -416,8 +416,8 @@ export class ChatView extends LitElement {
     try {
       const history = await loadHistory()
       if (loadSeq !== this._historyLoadSeq) return
-      // Wenn zwischen Start und Ende bereits neue Messages entstanden sind
-      // (z. B. Dashboard-Prompt wurde gesendet), darf History diese nicht überschreiben.
+      // If new messages were created between start and end
+      // (e.g. a dashboard prompt was sent), history must not overwrite them.
       if (this._chat.messages.length > 0) return
 
       const newMessages = history.map(m => ({
@@ -435,7 +435,7 @@ export class ChatView extends LitElement {
       this._chat = {
         ...this._chat,
         statusError: true,
-        statusText:  `Fehler: ${e instanceof Error ? e.message : String(e)}`,
+        statusText:  `Error: ${e instanceof Error ? e.message : String(e)}`,
       }
     }
   }
@@ -443,12 +443,12 @@ export class ChatView extends LitElement {
   private async _sendPrompt(prompt: string) {
     if (!prompt.trim() || this._chat.loading) return
 
-    // Verhindert, dass ein parallel laufendes _loadHistory() den gerade
-    // angelegten User-Input nachträglich überschreibt.
+    // Prevents a concurrent _loadHistory() from overwriting
+    // the just-created user input afterwards.
     this._historyLoadSeq++
     this._activeRequestId = this._createRequestId()
     this._cancelRequested = false
-    // Platzhalter für die Assistant-Antwort, wird live befüllt
+    // Placeholder for the assistant response, filled live
     const assistantId = this._idCounter++
     this._streamingId = assistantId
     this._streamingContent = ''
@@ -463,7 +463,7 @@ export class ChatView extends LitElement {
         { id: assistantId, role: 'assistant' as const, content: '' },
       ],
       loading:     true,
-      statusText:  'Denke…',
+      statusText:  'Thinking…',
       statusError: false,
     }
     this.dispatchEvent(new CustomEvent('chat-started', { bubbles: true, composed: true }))
@@ -474,7 +474,7 @@ export class ChatView extends LitElement {
       const result = await streamChat(prompt, {
         onReasoningToken: token => {
           if (this._newRoundPending) {
-            // Erst beim ersten Token der neuen Runde resetten – bis dahin bleibt der alte Text sichtbar
+            // Reset only on the first token of the new round – until then the old text remains visible
             this._reasoningContent = token
             this._newRoundPending = false
           } else {
@@ -491,7 +491,7 @@ export class ChatView extends LitElement {
           }
         },
         onToolCall: data => {
-          this._chat = { ...this._chat, statusText: `Führe aus: ${data.command}` }
+          this._chat = { ...this._chat, statusText: `Running: ${data.command}` }
           this._streamingEntries = [
             ...this._streamingEntries,
             { toolName: data.name || 'tool', command: data.command, output: '', exitCode: -1, wasExecuted: false, status: 'running' },
@@ -518,10 +518,10 @@ export class ChatView extends LitElement {
             }
             return e
           })
-          this._chat = { ...this._chat, statusText: 'Verarbeite Ergebnis…' }
+          this._chat = { ...this._chat, statusText: 'Processing result…' }
         },
         onRoundStart: data => {
-          this._chat = { ...this._chat, statusText: `Tool-Runde ${data.round}…` }
+          this._chat = { ...this._chat, statusText: `Tool round ${data.round}…` }
           this._newRoundPending = true
         },
       }, this.sessionId || undefined, this._enabledTools.length ? this._enabledTools : undefined, this.agentId || undefined, this._activeRequestId || undefined)
@@ -539,7 +539,7 @@ export class ChatView extends LitElement {
         ? result.commands
         : streamedCommands
       const finalResponseText = result.finalStatus === 'user_cancelled'
-        ? (this._streamingContent || result.response || 'Vom Nutzer abgebrochen.')
+        ? (this._streamingContent || result.response || 'Cancelled by user.')
         : result.response
 
       const newMessages = this._chat.messages.map(m =>
@@ -553,7 +553,7 @@ export class ChatView extends LitElement {
           : m
       )
       const finalStatusText = result.finalStatus === 'user_cancelled'
-        ? 'Vom Nutzer abgebrochen'
+        ? 'Cancelled by user'
         : result.finalStatus === 'timeout'
           ? 'Timeout'
           : (this._enabledTools.length ? `Tools: ${this._enabledTools.join(', ')}` : '')
@@ -570,7 +570,7 @@ export class ChatView extends LitElement {
       this._streamingEntries = []
       this._emitMessagesChanged()
     } catch (e) {
-      const errText = `Fehler: ${e instanceof Error ? e.message : String(e)}`
+      const errText = `Error: ${e instanceof Error ? e.message : String(e)}`
       const newMessages = this._chat.messages.map(m =>
         m.id === assistantId ? { ...m, content: `⚠️ ${errText}` } : m
       )
@@ -610,14 +610,14 @@ export class ChatView extends LitElement {
   private async _cancelRun() {
     if (!this._activeRequestId || this._cancelRequested) return
     this._cancelRequested = true
-    this._chat = { ...this._chat, statusText: 'Abbruch angefordert…', statusError: false }
+    this._chat = { ...this._chat, statusText: 'Cancellation requested…', statusError: false }
 
     try {
       await cancelChat(this._activeRequestId)
     } catch (e) {
       this._chat = {
         ...this._chat,
-        statusText: `Fehler beim Abbrechen: ${e instanceof Error ? e.message : String(e)}`,
+        statusText: `Error while cancelling: ${e instanceof Error ? e.message : String(e)}`,
         statusError: true,
       }
     }
@@ -638,7 +638,7 @@ export class ChatView extends LitElement {
     }))
   }
 
-  /** Aggregiert alle CommandResults aus allen Nachrichten als ToolCallEntries */
+  /** Aggregates all CommandResults from all messages as ToolCallEntries */
   private _toolCallEntries(messages: Message[]): ToolCallEntry[] {
     const entries: ToolCallEntry[] = []
     for (const msg of messages) {
@@ -799,7 +799,7 @@ export class ChatView extends LitElement {
 
   private _workingText() {
     if (!this._chat.loading) return ''
-    return this._chat.statusText || 'Denke…'
+    return this._chat.statusText || 'Thinking…'
   }
 
   render() {
@@ -825,7 +825,7 @@ export class ChatView extends LitElement {
           <div
             class="resize-handle"
             role="separator"
-            aria-label="Breite Tool-Calls anpassen"
+            aria-label="Adjust Tool-Calls width"
             aria-orientation="vertical"
             tabindex="0"
             @pointerdown=${(ev: PointerEvent) => this._startResize('toolCalls', ev)}
@@ -840,7 +840,7 @@ export class ChatView extends LitElement {
               ? html`
                   <div class="empty-state">
                     <div class="icon">⌨️</div>
-                    <p>Stell mir eine Frage oder wähle einen Use-Case.</p>
+                    <p>Ask me a question or select a use case.</p>
                   </div>
                 `
               : repeat(
@@ -870,7 +870,7 @@ export class ChatView extends LitElement {
           <div
             class="resize-handle"
             role="separator"
-            aria-label="Breite Info-Panel anpassen"
+            aria-label="Adjust Info-Panel width"
             aria-orientation="vertical"
             tabindex="0"
             @pointerdown=${(ev: PointerEvent) => this._startResize('info', ev)}
@@ -889,9 +889,9 @@ export class ChatView extends LitElement {
       <footer>
         ${this._toolPickerOpen ? html`
           <div class="tool-picker">
-            <div class="tool-picker-title">🔧 Tools für diese Session</div>
+            <div class="tool-picker-title">🔧 Tools for this session</div>
             ${this._availableTools.length === 0
-              ? html`<span style="font-size:12px;color:#64748b">Keine Tools verfügbar.</span>`
+              ? html`<span style="font-size:12px;color:#64748b">No tools available.</span>`
               : html`
                 <div class="tool-picker-list">
                   ${this._availableTools.map(t => html`
@@ -908,8 +908,8 @@ export class ChatView extends LitElement {
 
         <div class="input-row">
           <textarea
-            placeholder="Nachricht eingeben… (Cmd+Enter zum Senden)"
-            aria-label="Nachricht eingeben"
+            placeholder="Enter message… (Cmd+Enter to send)"
+            aria-label="Enter message"
             @keydown=${this._onKeydown}
             ?disabled=${this._chat.loading}
           ></textarea>
@@ -918,22 +918,22 @@ export class ChatView extends LitElement {
           <button
             class="terminal-toggle ${this._toolPickerOpen || this._enabledTools.length > 0 ? 'active' : ''}"
             @click=${this._toggleToolPicker}
-            title="Tools für diese Session konfigurieren"
+            title="Configure tools for this session"
             aria-pressed=${this._toolPickerOpen ? 'true' : 'false'}
           >🔧 Tools${this._enabledTools.length > 0 ? ` (${this._enabledTools.length})` : ''}</button>
 
           <button
             class="terminal-toggle ${this._panels.toolCallsOpen ? 'active' : ''}"
             @click=${() => { this._panels = { ...this._panels, toolCallsOpen: !this._panels.toolCallsOpen } }}
-            title="Tool-Calls ein-/ausblenden"
+            title="Show/hide Tool-Calls"
             aria-pressed=${this._panels.toolCallsOpen ? 'true' : 'false'}
-            aria-label="Tool-Calls ein-/ausblenden"
+            aria-label="Show/hide Tool-Calls"
           >Tool Calls</button>
 
           <button
             class="terminal-toggle ${this._panels.infoOpen ? 'active' : ''}"
             @click=${this._toggleInfo}
-            title="Info-Panel ein-/ausblenden"
+            title="Show/hide Info-Panel"
             aria-pressed=${this._panels.infoOpen ? 'true' : 'false'}
           >ℹ Info</button>
 
@@ -950,9 +950,9 @@ export class ChatView extends LitElement {
               class="cancel"
               @click=${this._cancelRun}
               ?disabled=${this._cancelRequested}
-              aria-label="Laufenden Tool-Call abbrechen"
+              aria-label="Cancel running tool call"
             >
-              ${this._cancelRequested ? 'Abbrechen…' : 'Abbrechen'}
+              ${this._cancelRequested ? 'Cancelling…' : 'Cancel'}
             </button>
           ` : ''}
 
@@ -960,9 +960,9 @@ export class ChatView extends LitElement {
             class="primary"
             @click=${this._send}
             ?disabled=${this._chat.loading}
-            aria-label="Nachricht senden"
+            aria-label="Send message"
           >
-            Senden
+            Send
           </button>
         </div>
       </footer>

--- a/src/06_app/bashGPT.Web/src/components/message-bubble.ts
+++ b/src/06_app/bashGPT.Web/src/components/message-bubble.ts
@@ -83,7 +83,7 @@ export class MessageBubble extends LitElement {
 
       .content { color: var(--color-text, #e5e7eb); }
 
-      /* Reasoning-Modus: gedämpfte Darstellung */
+      /* Reasoning mode: muted display */
       .reasoning-label {
         font-size: 10px;
         color: #475569;
@@ -97,7 +97,7 @@ export class MessageBubble extends LitElement {
         white-space: pre-wrap;
       }
 
-      /* Markdown-Stile */
+      /* Markdown styles */
       .content pre {
         background: #020617;
         border: 1px solid #1e293b;
@@ -146,10 +146,10 @@ export class MessageBubble extends LitElement {
 
   private get _html() {
     if (this.reasoning) {
-      // Reasoning live: plain text, kein Markdown-Parsing
+      // Reasoning live: plain text, no Markdown parsing
       return html`<span>${this.content}</span>`
     }
-    // Thinking-Blöcke (<thinking>…</thinking>) aus dem Content entfernen
+    // Remove thinking blocks (<thinking>…</thinking>) from content
     const clean = this.content
       .replace(/<thinking>[\s\S]*?<\/thinking>/gi, '')
       .trim()
@@ -164,9 +164,9 @@ export class MessageBubble extends LitElement {
     return html`
       <div class="bubble ${this.role}">
         <div class="meta-row">
-          <span class="meta">${this.role === 'user' ? 'Du' : 'bashGPT'}</span>
+          <span class="meta">${this.role === 'user' ? 'You' : 'bashGPT'}</span>
         </div>
-        ${this.reasoning ? html`<div class="reasoning-label">Denkt…</div>` : ''}
+        ${this.reasoning ? html`<div class="reasoning-label">Thinking…</div>` : ''}
         <div class="content ${this.reasoning ? 'is-reasoning' : ''}">${this._html}</div>
       </div>
     `

--- a/src/06_app/bashGPT.Web/src/components/settings-view.ts
+++ b/src/06_app/bashGPT.Web/src/components/settings-view.ts
@@ -255,7 +255,7 @@ export class SettingsView extends LitElement {
     this._settings = this._normalizeSettings(await getSettings())
     this._loading = false
     if (!this._settings) {
-      this._status = 'Einstellungen konnten nicht geladen werden. Bitte stelle sicher, dass der Server läuft.'
+      this._status = 'Settings could not be loaded. Please ensure that the server is running.'
       this._statusOk = false
     }
   }
@@ -318,7 +318,7 @@ export class SettingsView extends LitElement {
     if (!this._settings) return
 
     if (!this._settings.ollama.host.trim()) {
-      this._status = 'Ollama Host darf nicht leer sein.'
+      this._status = 'Ollama Host must not be empty.'
       this._statusOk = false
       return
     }
@@ -326,10 +326,10 @@ export class SettingsView extends LitElement {
     this._loading = true
     try {
       await saveSettings(this._buildSavePayload(this._settings))
-      this._status = 'Einstellungen gespeichert.'
+      this._status = 'Settings saved.'
       this._statusOk = true
     } catch (e) {
-      this._status = `Fehler: ${e instanceof Error ? e.message : String(e)}`
+      this._status = `Error: ${e instanceof Error ? e.message : String(e)}`
       this._statusOk = false
     } finally {
       this._loading = false
@@ -342,34 +342,34 @@ export class SettingsView extends LitElement {
     const result = await testConnection()
     this._testing = false
     if (result.ok) {
-      this._status = `Verbindung OK${result.latencyMs != null ? ` (${result.latencyMs} ms)` : ''}`
+      this._status = `Connection OK${result.latencyMs != null ? ` (${result.latencyMs} ms)` : ''}`
       this._statusOk = true
     } else {
-      this._status = `Verbindung fehlgeschlagen: ${result.error ?? 'Unbekannt'}`
+      this._status = `Connection failed: ${result.error ?? 'Unknown'}`
       this._statusOk = false
     }
   }
 
   private _clearHistory() {
-    if (!confirm('Gesamten Verlauf wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.')) return
+    if (!confirm('Really delete entire history? This action cannot be undone.')) return
     this.dispatchEvent(new CustomEvent('clear-history', { bubbles: true, composed: true }))
   }
 
   private _renderProviderDocumentation() {
     return html`
-      <h3>Ollama Doku</h3>
-      <p>Diese Optionen werden im Request an <code>/v1/chat/completions</code> gesendet (OpenAI-kompatibler Endpunkt). Kurz-Hinweise findest du direkt unter den Eingabefeldern links.</p>
+      <h3>Ollama Docs</h3>
+      <p>These options are sent in the request to <code>/v1/chat/completions</code> (OpenAI-compatible endpoint). Brief hints are shown directly below the input fields on the left.</p>
       <div class="doc-group">
-        <span class="doc-label">Basis</span>
+        <span class="doc-label">Basic</span>
         <ul class="doc-list">
-          <li><code>model</code> - lokales Modell, z.B. <code>gpt-oss:20b</code>. Wirkung: steuert Fähigkeit, RAM-Bedarf und Latenz.</li>
-          <li><code>host</code> - Standard: <code>http://localhost:11434</code>. Wirkung: Zielinstanz für alle Ollama-Requests.</li>
+          <li><code>model</code> - local model, e.g. <code>gpt-oss:20b</code>. Effect: controls capability, RAM requirement, and latency.</li>
+          <li><code>host</code> - Default: <code>http://localhost:11434</code>. Effect: target instance for all Ollama requests.</li>
         </ul>
       </div>
       <div class="doc-group">
         <span class="doc-label">Sampling</span>
         <ul class="doc-list">
-          <li>Weitere Sampling-Parameter werden im Open-Source-Build derzeit nicht persistent konfiguriert.</li>
+          <li>Additional sampling parameters are not currently persistently configured in the open-source build.</li>
         </ul>
       </div>
       <div class="doc-links">
@@ -384,35 +384,35 @@ export class SettingsView extends LitElement {
 
     if (this._loading && !s) {
       return html`
-        <h2>Einstellungen</h2>
+        <h2>Settings</h2>
         <div class="loading-placeholder">
-          <div class="spinner"></div> Einstellungen werden geladen…
+          <div class="spinner"></div> Loading settings…
         </div>
       `
     }
 
     return html`
-      <h2>Einstellungen</h2>
+      <h2>Settings</h2>
       <div class="layout">
       <div class="settings-main">
       <div class="section">
-        <div class="section-label">Verbindung</div>
+        <div class="section-label">Connection</div>
 
         <div class="field">
           <label>Provider</label>
           <input type="text" .value=${s?.provider ?? 'ollama'} disabled />
-          <div class="hint">Open-Source-Builds nutzen ausschließlich Ollama.</div>
+          <div class="hint">Open-source builds use Ollama exclusively.</div>
         </div>
         <div class="field">
-          <label>Ollama Modell</label>
+          <label>Ollama Model</label>
           <input
             type="text"
             .value=${s?.ollama.model ?? ''}
             @input=${(e: InputEvent) => this._setOllamaModel((e.target as HTMLInputElement).value)}
             ?disabled=${!s || this._loading}
-            placeholder="z.B. gpt-oss:20b"
+            placeholder="e.g. gpt-oss:20b"
           />
-          <div class="hint">Steuert Qualität, Geschwindigkeit und Ressourcenbedarf.</div>
+          <div class="hint">Controls quality, speed, and resource usage.</div>
         </div>
 
         <div class="field">
@@ -423,22 +423,22 @@ export class SettingsView extends LitElement {
             @input=${(e: InputEvent) => this._setOllamaHost((e.target as HTMLInputElement).value)}
             ?disabled=${!s || this._loading}
           />
-          <div class="hint">Standard lokal: <code>http://localhost:11434</code>.</div>
+          <div class="hint">Default locally: <code>http://localhost:11434</code>.</div>
         </div>
 
         <div class="actions">
           <button @click=${this._test} ?disabled=${!s || this._testing || this._loading}>
-            ${this._testing ? 'Teste…' : 'Verbindung testen'}
+            ${this._testing ? 'Testing…' : 'Test connection'}
           </button>
         </div>
       </div>
 
       <div class="section">
-        <div class="section-label">Verlauf</div>
-        <div class="hint">Löscht alle gespeicherten Sessions aus dem Browser-Speicher und setzt die Server-History zurück.</div>
+        <div class="section-label">History</div>
+        <div class="hint">Deletes all saved sessions from browser storage and resets server history.</div>
         <div class="actions" style="margin-top: 12px;">
           <button class="danger" @click=${this._clearHistory}>
-            Gesamten Verlauf löschen
+            Delete entire history
           </button>
         </div>
       </div>
@@ -447,7 +447,7 @@ export class SettingsView extends LitElement {
 
       <div class="actions">
         <button class="primary" @click=${this._save} ?disabled=${!s || this._loading}>
-          ${this._loading ? 'Speichert…' : 'Speichern'}
+          ${this._loading ? 'Saving…' : 'Save'}
         </button>
       </div>
 
@@ -459,7 +459,7 @@ export class SettingsView extends LitElement {
         ` : ''}
       </div>
       </div>
-      <aside class="provider-doc" aria-label="Provider Dokumentation">
+      <aside class="provider-doc" aria-label="Provider Documentation">
         ${this._renderProviderDocumentation()}
       </aside>
       </div>


### PR DESCRIPTION
## Summary

- Translates all German UI strings, ARIA labels, placeholders, status messages, and button labels to English
- Translates German code comments and JSDoc to English
- Sets `<html lang="en">` in `index.html`

Affected files: `index.html`, `chat-view.ts`, `chat-app.ts`, `message-bubble.ts`, `settings-view.ts`

## Test plan

- [x] All 28 existing frontend tests pass (`npm test`)
- [x] Visually verify UI text in the browser (Settings, Chat, empty state, status messages)

Closes #222