### PR TITLE
feat(sdk): NuGet-Publish-Workflow und README-Badges hinzufügen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish NuGet
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Pack & Publish SDK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.301'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Pack bashGPT.Tools
+        run: >
+          dotnet pack src/02_abstractions/bashGPT.Tools/bashGPT.Tools.csproj
+          --no-restore
+          --configuration Release
+          -p:Version=${{ github.event.release.tag_name }}
+          --output ./nupkgs
+
+      - name: Pack bashGPT.Agents
+        run: >
+          dotnet pack src/02_abstractions/bashGPT.Agents/bashGPT.Agents.csproj
+          --no-restore
+          --configuration Release
+          -p:Version=${{ github.event.release.tag_name }}
+          --output ./nupkgs
+
+      - name: Push to NuGet.org
+        run: >
+          dotnet nuget push ./nupkgs/*.nupkg
+          --api-key ${{ secrets.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # bashGPT
 
+[![CI](https://github.com/slekrem/bashGPT/actions/workflows/ci.yml/badge.svg)](https://github.com/slekrem/bashGPT/actions/workflows/ci.yml)
+[![NuGet bashGPT.Tools](https://img.shields.io/nuget/v/bashGPT.Tools.svg?label=bashGPT.Tools)](https://www.nuget.org/packages/bashGPT.Tools)
+[![NuGet bashGPT.Agents](https://img.shields.io/nuget/v/bashGPT.Agents.svg?label=bashGPT.Agents)](https://www.nuget.org/packages/bashGPT.Agents)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Local AI assistant for shell workflows. bashGPT can optionally collect context such as the current directory, git status, OS, and shell, send it to an LLM through Ollama, and help execute the resulting shell commands with the right safety level.
 
 ## Features
@@ -129,12 +134,20 @@ Agents are specialized chat modes with their own system prompt and tool set. The
 
 External tools and agents can be developed as standalone .NET assemblies and loaded into bashGPT without recompiling the host.
 
-**NuGet packages:**
+**Install via NuGet:**
+
+```bash
+# Tool SDK — implement ITool
+dotnet add package bashGPT.Tools
+
+# Agent SDK — implement AgentBase (includes bashGPT.Tools transitively)
+dotnet add package bashGPT.Agents
+```
 
 | Package | Purpose |
 |---|---|
-| `bashGPT.Tools` | Implement custom `ITool` types |
-| `bashGPT.Agents` | Implement custom `AgentBase` subclasses (includes `bashGPT.Tools` transitively) |
+| [`bashGPT.Tools`](https://www.nuget.org/packages/bashGPT.Tools) | Implement custom `ITool` types |
+| [`bashGPT.Agents`](https://www.nuget.org/packages/bashGPT.Agents) | Implement custom `AgentBase` subclasses (includes `bashGPT.Tools` transitively) |
 
 Both packages are versioned with SemVer 2. While on `0.x`, minor bumps may contain breaking changes — pin to a compatible version in plugin projects.
 

--- a/src/02_abstractions/bashGPT.Agents/bashGPT.Agents.csproj
+++ b/src/02_abstractions/bashGPT.Agents/bashGPT.Agents.csproj
@@ -7,6 +7,8 @@
 
     <!-- NuGet packaging -->
     <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>bashGPT.Agents</PackageId>
     <Title>bashGPT Agent SDK</Title>
     <Description>Abstractions and base types for implementing agents for the bashGPT server. Subclass AgentBase to create a self-contained agent with its own tools, system prompts, and LLM configuration.</Description>

--- a/src/02_abstractions/bashGPT.Tools/bashGPT.Tools.csproj
+++ b/src/02_abstractions/bashGPT.Tools/bashGPT.Tools.csproj
@@ -7,6 +7,8 @@
 
     <!-- NuGet packaging -->
     <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>bashGPT.Tools</PackageId>
     <Title>bashGPT Tool SDK</Title>
     <Description>Abstractions and base types for implementing tools that can be exposed to LLMs via the bashGPT server. Implement ITool and drop the assembly into the plugin directory to extend bashGPT without recompiling the host.</Description>


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — triggers on `release: published`, packs `bashGPT.Tools` and `bashGPT.Agents` with the release tag as version, and pushes to nuget.org via `NUGET_API_KEY` secret
- Adds `IncludeSymbols` + `SymbolPackageFormat: snupkg` to both SDK `.csproj` files for source-link debugging
- Adds CI, NuGet, and License badges to `README.md`
- Adds `dotnet add package` install instructions in the Plugin SDK section

## Before merging

- [ ] Add `NUGET_API_KEY` as a GitHub Actions secret (Settings → Secrets → Actions)

## Test plan

- [ ] `dotnet pack src/02_abstractions/bashGPT.Tools/bashGPT.Tools.csproj -p:Version=0.1.0 --output /tmp/test-nupkgs` produces `.nupkg` + `.snupkg`
- [ ] `dotnet pack src/02_abstractions/bashGPT.Agents/bashGPT.Agents.csproj -p:Version=0.1.0 --output /tmp/test-nupkgs` produces `.nupkg` + `.snupkg`
- [ ] Workflow file is valid YAML and appears in Actions tab after merge
- [ ] README badges render correctly on GitHub

Closes #225