### PR TITLE
fix(ci): v-Präfix vom Release-Tag vor NuGet-Version entfernen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           dotnet-version: '9.0.301'
 
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
       - name: Restore
         run: dotnet restore
 
@@ -26,7 +29,7 @@ jobs:
           dotnet pack src/02_abstractions/bashGPT.Tools/bashGPT.Tools.csproj
           --no-restore
           --configuration Release
-          -p:Version=${{ github.event.release.tag_name }}
+          -p:Version=${{ env.VERSION }}
           --output ./nupkgs
 
       - name: Pack bashGPT.Agents
@@ -34,7 +37,7 @@ jobs:
           dotnet pack src/02_abstractions/bashGPT.Agents/bashGPT.Agents.csproj
           --no-restore
           --configuration Release
-          -p:Version=${{ github.event.release.tag_name }}
+          -p:Version=${{ env.VERSION }}
           --output ./nupkgs
 
       - name: Push to NuGet.org


### PR DESCRIPTION
## Problem

`github.event.release.tag_name` liefert `v0.1.0` — NuGet akzeptiert nur `0.1.0` ohne `v`-Präfix.

Fehler: `PackageVersion string specified 'v0.1.0' is invalid.`

## Fix

Neuer Schritt `Get version` strippt das `v` via Shell-Parameter-Expansion:
```bash
echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
```

Beide Pack-Schritte nutzen jetzt `${{ env.VERSION }}`.

## Test plan

- [ ] CI ist grün
- [ ] Nach Merge: Release `v0.1.0` erneut triggern (Edit + Republish) oder `v0.1.0` löschen und neu erstellen