### PR TITLE
feat(ci): CodeQL Security Scanning für C# und TypeScript hinzufügen

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [csharp, javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.301'
+
+      - name: Setup Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+          cache: 'npm'
+          cache-dependency-path: src/06_app/bashGPT.Web/package-lock.json
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Build (.NET)
+        if: matrix.language == 'csharp'
+        run: dotnet build --configuration Release
+
+      - name: Install frontend dependencies
+        if: matrix.language == 'javascript-typescript'
+        working-directory: src/06_app/bashGPT.Web
+        run: npm ci
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Adds `.github/workflows/codeql.yml` with GitHub CodeQL static analysis:

- **Triggers:** push/PR auf `main` + wöchentlich montags 06:00 UTC
- **Matrix:** separate Jobs für `csharp` und `javascript-typescript`
- C#-Job baut mit `dotnet build` vor der Analyse (erforderlich für CodeQL)
- TypeScript-Job installiert npm-Dependencies

## Test plan

- [ ] Beide Matrix-Jobs (`csharp`, `javascript-typescript`) laufen grün
- [ ] Security-Tab auf GitHub zeigt CodeQL-Ergebnisse

Closes #226