### PR TITLE
feat: Windows-Kompatibilität in CI und Dokumentation verankern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,13 @@ on:
 
 jobs:
   test:
-    name: Build & Test
-    runs-on: ubuntu-latest
+    name: Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout
@@ -48,5 +53,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results
+          name: test-results-${{ matrix.os }}
           path: '**/test-results.trx'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Local AI assistant for shell workflows. bashGPT can optionally collect context s
 - Browser UI with chat history, session management, and agent selection
 - Specialized agents (`shell`, `dev`) with dedicated tool sets
 - Modular tool ecosystem for filesystem, git, build, testing, fetch, and shell workflows
-- Plugin system for external tools and agents via `~/.config/bashgpt/plugins/`
+- Plugin system for external tools and agents via `~/.config/bashgpt/plugins/` (Windows: `%APPDATA%\bashgpt\plugins\`)
 - `bashGPT.Tools` and `bashGPT.Agents` available as NuGet packages for plugin development
 - MIT licensed
 
@@ -60,7 +60,7 @@ dotnet run --project src/06_app/bashGPT.Cli -- --force-tools "analyze this direc
 ```
 
 ## Configuration
-By default, the config file is stored at `~/.config/bashgpt/config.json`.
+By default, the config file is stored at `~/.config/bashgpt/config.json` (Windows: `%APPDATA%\bashgpt\config.json`).
 
 ```bash
 # Show configuration
@@ -116,7 +116,7 @@ Available server flags: `--provider`, `--model`, `--port`, `--no-browser`, `--ve
 
 Notes:
 - The UI provides chat history, session management, agent selection, manually selectable tools, and visibility into executed tool results.
-- Sessions are stored in `~/.config/bashgpt/sessions/` (max. 20 sessions).
+- Sessions are stored in `~/.config/bashgpt/sessions/` (Windows: `%APPDATA%\bashgpt\sessions\`), max. 20 sessions.
 - Available API endpoints include `/api/sessions/*`, `/api/agents`, `/api/agents/<id>/info-panel`, `/api/tools`, `/api/chat/stream`, and `/api/chat/cancel`.
 - All tools discovered in the plugin directory are available for selection in the browser UI. Tool selection is UI-driven.
 - Agents with fixed tool sets such as `shell` and `dev` remain an intentional trust boundary and can expose more powerful tools.

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -73,10 +73,17 @@ Optional overrides:
 The plugin directory must be named after the main assembly:
 
 ```
+# macOS / Linux
 ~/.config/bashgpt/plugins/
   MyPlugin/
     MyPlugin.dll        ← main assembly (name must match directory)
     SomeDependency.dll  ← private dependencies (optional)
+
+# Windows
+%APPDATA%\bashgpt\plugins\
+  MyPlugin\
+    MyPlugin.dll
+    SomeDependency.dll
 ```
 
 **Rules:**
@@ -87,9 +94,16 @@ The plugin directory must be named after the main assembly:
 ## Installation
 
 ```bash
+# macOS / Linux
 mkdir -p ~/.config/bashgpt/plugins/MyPlugin
 cp MyPlugin/bin/Release/net9.0/MyPlugin.dll ~/.config/bashgpt/plugins/MyPlugin/
 # copy optional dependencies as well
+```
+
+```powershell
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force "$env:APPDATA\bashgpt\plugins\MyPlugin"
+Copy-Item MyPlugin\bin\Release\net9.0\MyPlugin.dll "$env:APPDATA\bashgpt\plugins\MyPlugin\"
 ```
 
 The plugin is loaded automatically the next time `bashgpt-server` or `bashgpt` (CLI) starts.


### PR DESCRIPTION
## Summary

Der Code war bereits zu ~90% Windows-ready (Pfade, Shell-Detection, cmd/PowerShell-Tools). Dieser PR verankert das in CI und Dokumentation.

- **ci.yml** — Matrix auf `ubuntu-latest`, `windows-latest`, `macos-latest` erweitert; Artifact-Namen pro OS eindeutig
- **README.md** — Windows-Pfade (`%APPDATA%\bashgpt`) bei Konfiguration, Sessions und Plugin-Verzeichnis ergänzt
- **docs/plugin-authoring.md** — Separate Verzeichnis-Darstellung für Windows; PowerShell-Installationsschritte hinzugefügt

## Test plan

- [ ] Alle drei CI-Matrix-Jobs (ubuntu, windows, macos) laufen grün
- [ ] Windows-Pfade in README und Docs sind korrekt

Closes #230