### PR TITLE
ci: Frontend-Vitest-Suite als Pflichtschritt in CI aufnehmen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         working-directory: src/06_app/bashGPT.Web
         run: npm ci
 
+      - name: Test frontend
+        working-directory: src/06_app/bashGPT.Web
+        run: npm test
+
       - name: Build frontend
         working-directory: src/06_app/bashGPT.Web
         run: npm run build


### PR DESCRIPTION
## Summary

Ergänzt `npm test` (Vitest) als eigenen Schritt in `ci.yml`, direkt nach `npm ci` und vor dem Frontend-Build. Läuft auf allen drei Plattformen (ubuntu, windows, macos).

Ein fehlgeschlagener Vitest-Test bricht den PR-Check ab — UI-Regressionen in Session-Handling, API-Glue und Chat-View werden damit automatisch erkannt.

## Test plan

- [ ] Alle drei Matrix-Jobs laufen grün inkl. `Test frontend`
- [ ] Schritt erscheint im Actions-Log zwischen `Install frontend dependencies` und `Build frontend`

Closes #189