### PR TITLE
docs: release.yml für automatisch kategorisierte Release Notes hinzufügen

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking-change
+    - title: "New Features"
+      labels:
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - bug
+    - title: "Frontend"
+      labels:
+        - frontend
+        - ui
+    - title: "Documentation"
+      labels:
+        - documentation
+    - title: "Tests & Quality"
+      labels:
+        - testing
+    - title: "Maintenance"
+      labels:
+        - dependencies
+        - backend


### PR DESCRIPTION
## Summary

Fügt `.github/release.yml` hinzu — GitHub nutzt diese Datei, um bei `gh release create --generate-notes` die PRs automatisch nach Labels zu kategorisieren.

**Kategorien:**
| Kategorie | Labels |
|-----------|--------|
| Breaking Changes | `breaking-change` |
| New Features | `enhancement` |
| Bug Fixes | `bug` |
| Frontend | `frontend`, `ui` |
| Documentation | `documentation` |
| Tests & Quality | `testing` |
| Maintenance | `dependencies`, `backend` |

**Verwendung für zukünftige Releases:**
```bash
gh release create v0.2.0 --generate-notes --title "v0.2.0"
```

Closes #188