### PR TITLE
feat: add file-based logging via Serilog rolling file sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **File-based logging** — Serilog rolling file sink writes warnings and errors to
+  `~/.config/bashgpt/logs/` (Windows: `%APPDATA%\bashgpt\logs\`); 14 daily files retained (#100)
+
 ## [0.1.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Available server flags: `--provider`, `--model`, `--port`, `--no-browser`, `--ve
 Notes:
 - The UI provides chat history, session management, agent selection, manually selectable tools, and visibility into executed tool results.
 - Sessions are stored in `~/.config/bashgpt/sessions/` (Windows: `%APPDATA%\bashgpt\sessions\`), max. 20 sessions.
+- Log files are written to `~/.config/bashgpt/logs/` (Windows: `%APPDATA%\bashgpt\logs\`), rolling daily, 14 files retained.
 - Available API endpoints include `/api/sessions/*`, `/api/agents`, `/api/agents/<id>/info-panel`, `/api/tools`, `/api/chat/stream`, and `/api/chat/cancel`.
 - All tools discovered in the plugin directory are available for selection in the browser UI. Tool selection is UI-driven.
 - Agents with fixed tool sets such as `shell` and `dev` remain an intentional trust boundary and can expose more powerful tools.

--- a/src/01_core/bashGPT.Core/AppBootstrap.cs
+++ b/src/01_core/bashGPT.Core/AppBootstrap.cs
@@ -21,6 +21,9 @@ public static class AppBootstrap
     public static string GetPluginsDir(string? configDir = null) =>
         Path.Combine(configDir ?? GetDefaultConfigDir(), "plugins");
 
+    public static string GetLogsDir(string? configDir = null) =>
+        Path.Combine(configDir ?? GetDefaultConfigDir(), "logs");
+
     public static string GetSessionsDir(string? configDir = null) =>
         Path.Combine(configDir ?? GetDefaultConfigDir(), "sessions");
 

--- a/src/06_app/bashGPT.Cli/Program.cs
+++ b/src/06_app/bashGPT.Cli/Program.cs
@@ -3,6 +3,17 @@ using bashGPT.Core;
 using bashGPT.Core.Configuration;
 using bashGPT.Core.Versioning;
 using bashGPT.Cli;
+using Serilog;
+
+var logsDir = AppBootstrap.GetLogsDir();
+Directory.CreateDirectory(logsDir);
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Warning()
+    .WriteTo.File(
+        Path.Combine(logsDir, "cli-.log"),
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 14)
+    .CreateLogger();
 
 if (args is ["--version"])
 {
@@ -108,4 +119,16 @@ configCommand.Subcommands.Add(configGetCommand);
 configCommand.Subcommands.Add(configSetCommand);
 rootCommand.Subcommands.Add(configCommand);
 
-return await rootCommand.Parse(args).InvokeAsync();
+try
+{
+    return await rootCommand.Parse(args).InvokeAsync();
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Unhandled exception");
+    return 1;
+}
+finally
+{
+    await Log.CloseAndFlushAsync();
+}

--- a/src/06_app/bashGPT.Cli/bashGPT.Cli.csproj
+++ b/src/06_app/bashGPT.Cli/bashGPT.Cli.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.2" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/06_app/bashGPT.Server/Program.cs
+++ b/src/06_app/bashGPT.Server/Program.cs
@@ -1,11 +1,23 @@
 using System.Net;
 using bashGPT.Core;
 using bashGPT.Server.Extensions;
+using Serilog;
+using Serilog.Events;
 
-// Startup logger: used before the DI container is built (plugin loading, registry setup).
-// Disposed once the app is fully configured.
-using var startupLoggerFactory = LoggerFactory.Create(b =>
-    b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+var logsDir = AppBootstrap.GetLogsDir();
+Directory.CreateDirectory(logsDir);
+
+// Bootstrap logger: used before the DI container is built (plugin loading, registry setup).
+// Replaced by the full Serilog configuration once the host is built.
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Warning()
+    .WriteTo.File(
+        Path.Combine(logsDir, "server-.log"),
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 14)
+    .CreateBootstrapLogger();
+
+using var startupLoggerFactory = LoggerFactory.Create(b => b.AddSerilog());
 var startupLogger = startupLoggerFactory.CreateLogger("bashGPT.Server.Startup");
 
 var configService = ServerApplication.CreateConfigurationService();
@@ -31,7 +43,14 @@ builder.WebHost.ConfigureKestrel(o =>
     o.Listen(listenAddress, uri.Port);
     o.AllowSynchronousIO = true;
 });
-builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
+builder.Host.UseSerilog((ctx, services, cfg) => cfg
+    .ReadFrom.Configuration(ctx.Configuration)
+    .ReadFrom.Services(services)
+    .WriteTo.File(
+        Path.Combine(logsDir, "server-.log"),
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 14,
+        restrictedToMinimumLevel: LogEventLevel.Warning));
 
 builder.Services.AddBashGptServer(
     configService, toolRegistry,
@@ -43,7 +62,14 @@ app.UseBashGptPipeline();
 app.Logger.LogInformation("bashGPT Server running on {Url}/", url);
 app.Logger.LogInformation("Press Ctrl+C to stop.");
 
-await app.RunAsync();
+try
+{
+    await app.RunAsync();
+}
+finally
+{
+    await Log.CloseAndFlushAsync();
+}
 
 // Required for WebApplicationFactory<Program> in tests
 public partial class Program { }

--- a/src/06_app/bashGPT.Server/appsettings.json
+++ b/src/06_app/bashGPT.Server/appsettings.json
@@ -2,10 +2,12 @@
   "Server": {
     "Url": "http://127.0.0.1:5050"
   },
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Warning",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft.AspNetCore": "Warning"
+      }
     }
   }
 }

--- a/src/06_app/bashGPT.Server/bashGPT.Server.csproj
+++ b/src/06_app/bashGPT.Server/bashGPT.Server.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #100

## Summary

- `AppBootstrap.GetLogsDir()` returns the platform-correct log directory (`~/.config/bashgpt/logs/` on macOS/Linux, `%APPDATA%\bashgpt\logs\` on Windows)
- **Server**: Serilog bootstrap logger active before DI is built; full `UseSerilog()` configuration for the ASP.NET Core host — rolling file sink (`server-.log`, daily, 14 files), level controlled via `appsettings.json` Serilog section
- **CLI**: static `Log.Logger` with rolling file sink (`cli-.log`, daily, 14 files); unhandled exceptions captured via `Log.Fatal` in a top-level try/catch with `Log.CloseAndFlushAsync()` in the finally block
- Packages added: `Serilog.AspNetCore 8.0.3` + `Serilog.Sinks.File 6.0.0` (Server); `Serilog 4.2.0` + `Serilog.Sinks.File 6.0.0` (CLI)
- CHANGELOG and README updated with log path documentation

## Test plan

- [ ] All existing tests pass (`dotnet test`)
- [ ] Server builds without errors (`dotnet build src/06_app/bashGPT.Server`)
- [ ] CLI builds without errors (`dotnet build src/06_app/bashGPT.Cli`)
- [ ] After starting the server a `server-<date>.log` file appears in `~/.config/bashgpt/logs/`
- [ ] After running a CLI command a `cli-<date>.log` file appears in `~/.config/bashgpt/logs/`