### PR TITLE
feat: add sessionPath to GetAgentMarkdown and GetInfoPanelMarkdown

### DIFF
--- a/src/02_abstractions/bashGPT.Agents/AgentBase.cs
+++ b/src/02_abstractions/bashGPT.Agents/AgentBase.cs
@@ -100,17 +100,22 @@ public abstract class AgentBase
     /// <summary>
     /// Agent-specific markdown content for the info panel,
     /// excluding the LLM configuration section which is appended automatically.
+    /// Override when the panel content depends on session-scoped state
+    /// (e.g. loaded context files). The default implementation ignores
+    /// <paramref name="sessionPath"/>.
     /// </summary>
-    protected abstract string GetAgentMarkdown();
+    protected abstract string GetAgentMarkdown(string? sessionPath = null);
 
     /// <summary>
     /// Returns the full info-panel markdown for this agent.
     /// When <paramref name="effectiveConfig"/> is provided those values are used
     /// (e.g. already merged with provider defaults); otherwise <see cref="LlmConfig"/> is used.
+    /// When <paramref name="sessionPath"/> is provided it is forwarded to
+    /// <see cref="GetAgentMarkdown"/> so agents can render session-scoped state.
     /// </summary>
-    public string GetInfoPanelMarkdown(AgentLlmConfig? effectiveConfig = null)
+    public string GetInfoPanelMarkdown(AgentLlmConfig? effectiveConfig = null, string? sessionPath = null)
     {
-        var sb = new StringBuilder(GetAgentMarkdown().TrimEnd());
+        var sb = new StringBuilder(GetAgentMarkdown(sessionPath).TrimEnd());
 
         var cfg = effectiveConfig ?? LlmConfig;
         if (cfg is not null)

--- a/src/04_agents/bashGPT.Agents.Dev/DevAgent.cs
+++ b/src/04_agents/bashGPT.Agents.Dev/DevAgent.cs
@@ -168,40 +168,56 @@ public sealed class DevAgent : AgentBase
         }
     }
 
-    protected override string GetAgentMarkdown() => """
-        # Dev-Agent
+    protected override string GetAgentMarkdown(string? sessionPath = null)
+    {
+        var sb = new StringBuilder("""
+            # Dev-Agent
 
-        Specialized software development agent with full access to filesystem, git, build, and testing tools.
+            Specialized software development agent with full access to filesystem, git, build, and testing tools.
 
-        ## Capabilities
+            ## Capabilities
 
-        - Read, write, and search files
-        - Git operations (status, diff, log, branch, commit, checkout)
-        - Run builds and evaluate test results
-        - Execute shell commands
-        - Fetch web content
+            - Read, write, and search files
+            - Git operations (status, diff, log, branch, commit, checkout)
+            - Run builds and evaluate test results
+            - Execute shell commands
+            - Fetch web content
 
-        ## Enabled Tools
+            ## Enabled Tools
 
-        | Tool | Description |
-        |---|---|
-        | `fetch` | Fetch web content |
-        | `filesystem_read` | Read files and directories |
-        | `filesystem_write` | Create and edit files |
-        | `filesystem_search` | Search files by pattern |
-        | `git_status` | Show git status |
-        | `git_diff` | Compare changes |
-        | `git_log` | Inspect commit history |
-        | `git_branch` | Manage branches |
-        | `git_add` | Stage changes |
-        | `git_commit` | Create commits |
-        | `git_checkout` | Switch branches |
-        | `test_run` | Run tests |
-        | `build_run` | Start a build |
-        | `shell_exec` | Execute shell commands |
+            | Tool | Description |
+            |---|---|
+            | `fetch` | Fetch web content |
+            | `filesystem_read` | Read files and directories |
+            | `filesystem_write` | Create and edit files |
+            | `filesystem_search` | Search files by pattern |
+            | `git_status` | Show git status |
+            | `git_diff` | Compare changes |
+            | `git_log` | Inspect commit history |
+            | `git_branch` | Manage branches |
+            | `git_add` | Stage changes |
+            | `git_commit` | Create commits |
+            | `git_checkout` | Switch branches |
+            | `test_run` | Run tests |
+            | `build_run` | Start a build |
+            | `shell_exec` | Execute shell commands |
 
-        ## Notes
+            ## Notes
 
-        This agent follows strict tool-call rules and automatically retries invalid calls with corrected arguments.
-        """;
+            This agent follows strict tool-call rules and automatically retries invalid calls with corrected arguments.
+            """);
+
+        var loadedFiles = ContextFileCache.ReadFiles(sessionPath);
+        if (loadedFiles.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("## Loaded Context Files");
+            sb.AppendLine();
+            foreach (var path in loadedFiles)
+                sb.AppendLine($"- `{path}`");
+        }
+
+        return sb.ToString();
+    }
 }

--- a/src/04_agents/bashGPT.Agents.Shell/ShellAgent.cs
+++ b/src/04_agents/bashGPT.Agents.Shell/ShellAgent.cs
@@ -30,7 +30,7 @@ public sealed class ShellAgent : AgentBase
 
     public override IReadOnlyList<ITool> GetOwnedTools() => [_shellTool];
 
-    protected override string GetAgentMarkdown()
+    protected override string GetAgentMarkdown(string? sessionPath = null)
     {
         var toolName = _shellTool.Definition.Name;
         return $"""

--- a/src/05_plugins/bashGPT.Plugins.TestFixtures/FakeAgentFixture.cs
+++ b/src/05_plugins/bashGPT.Plugins.TestFixtures/FakeAgentFixture.cs
@@ -11,5 +11,5 @@ public sealed class FakeAgentFixture : AgentBase
     public override string Name => "Fake Agent";
     public override IReadOnlyList<string> EnabledTools => [];
     public override IReadOnlyList<string> SystemPrompt => ["You are a fake agent."];
-    protected override string GetAgentMarkdown() => "# Fake Agent\n\nUsed in plugin loader tests.";
+    protected override string GetAgentMarkdown(string? sessionPath = null) => "# Fake Agent\n\nUsed in plugin loader tests.";
 }

--- a/src/06_app/bashGPT.Server/Agents/GenericAgent.cs
+++ b/src/06_app/bashGPT.Server/Agents/GenericAgent.cs
@@ -23,7 +23,7 @@ internal sealed class GenericAgent : AgentBase
     public override IReadOnlyList<string> SystemPrompt =>
         ["You are a helpful assistant. Answer clearly and concisely."];
 
-    protected override string GetAgentMarkdown() => """
+    protected override string GetAgentMarkdown(string? sessionPath = null) => """
         # Generic Chat
 
         Default mode without specialized tools or an agent-specific system prompt.

--- a/src/06_app/bashGPT.Server/Controllers/AgentsController.cs
+++ b/src/06_app/bashGPT.Server/Controllers/AgentsController.cs
@@ -1,13 +1,14 @@
 using bashGPT.Agents;
 using bashGPT.Core.Configuration;
 using bashGPT.Core.Providers.Abstractions;
+using bashGPT.Server.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace bashGPT.Server.Controllers;
 
 [ApiController]
 [Route("api/agents")]
-public sealed class AgentsController(AgentRegistry? registry, ConfigurationService? configService) : ControllerBase
+public sealed class AgentsController(AgentRegistry? registry, ConfigurationService? configService, ServerSessionService sessionService) : ControllerBase
 {
     [HttpGet]
     public IActionResult GetAll()
@@ -20,7 +21,7 @@ public sealed class AgentsController(AgentRegistry? registry, ConfigurationServi
     }
 
     [HttpGet("{id}/info-panel")]
-    public async Task<IActionResult> GetInfoPanel(string id, CancellationToken ct)
+    public async Task<IActionResult> GetInfoPanel(string id, [FromQuery] string? sessionId, CancellationToken ct)
     {
         if (registry is null)
             return StatusCode(503, new { error = "Agent registry is unavailable." });
@@ -36,7 +37,8 @@ public sealed class AgentsController(AgentRegistry? registry, ConfigurationServi
             effectiveConfig = BuildEffectiveConfig(agent.LlmConfig, appConfig);
         }
 
-        return Ok(new { markdown = agent.GetInfoPanelMarkdown(effectiveConfig) });
+        var sessionPath = sessionService.GetSessionPath(sessionId);
+        return Ok(new { markdown = agent.GetInfoPanelMarkdown(effectiveConfig, sessionPath) });
     }
 
     private static AgentLlmConfig BuildEffectiveConfig(AgentLlmConfig? agentConfig, AppConfig appConfig)

--- a/src/06_app/bashGPT.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/06_app/bashGPT.Server/Extensions/ServiceCollectionExtensions.cs
@@ -68,7 +68,7 @@ internal static class ServiceCollectionExtensions
             sp.GetService<ConfigurationService>(),
             sp.GetService<ILogger<SettingsController>>()));
         services.AddSingleton(sp => new SessionsController(sp.GetService<SessionStore>()));
-        services.AddSingleton(sp => new AgentsController(sp.GetService<AgentRegistry>(), sp.GetService<ConfigurationService>()));
+        services.AddSingleton(sp => new AgentsController(sp.GetService<AgentRegistry>(), sp.GetService<ConfigurationService>(), sp.GetRequiredService<ServerSessionService>()));
         services.AddSingleton(sp => new ToolsController(sp.GetService<ToolRegistry>()));
         services.AddSingleton(sp => new LegacyController(sp.GetService<SessionStore>()));
         services.AddSingleton(sp => new ChatController(

--- a/src/06_app/bashGPT.Web/src/api.ts
+++ b/src/06_app/bashGPT.Web/src/api.ts
@@ -271,9 +271,11 @@ export async function getAgents(): Promise<Agent[]> {
   } catch { return [] }
 }
 
-export async function getAgentInfoPanel(id: string): Promise<string> {
+export async function getAgentInfoPanel(id: string, sessionId?: string): Promise<string> {
   try {
-    const res = await fetch(`/api/agents/${encodeURIComponent(id)}/info-panel`)
+    const url = new URL(`/api/agents/${encodeURIComponent(id)}/info-panel`, location.origin)
+    if (sessionId) url.searchParams.set('sessionId', sessionId)
+    const res = await fetch(url.toString())
     if (!res.ok) return ''
     const data = await res.json()
     return typeof data.markdown === 'string' ? data.markdown : ''

--- a/src/06_app/bashGPT.Web/src/components/chat-view.ts
+++ b/src/06_app/bashGPT.Web/src/components/chat-view.ts
@@ -770,7 +770,7 @@ export class ChatView extends LitElement {
     const id = this.agentId || 'generic'
     this._infoPanel = { markdown: '', loading: true }
     try {
-      const markdown = await getAgentInfoPanel(id)
+      const markdown = await getAgentInfoPanel(id, this.sessionId || undefined)
       this._infoPanel = { markdown, loading: false }
     } catch {
       this._infoPanel = { markdown: '', loading: false }

--- a/tests/02_abstractions/bashGPT.Agents.Tests/AgentArchitectureGuardTests.cs
+++ b/tests/02_abstractions/bashGPT.Agents.Tests/AgentArchitectureGuardTests.cs
@@ -10,7 +10,7 @@ file sealed class CustomAgent : AgentBase
     public override string Name => "Custom Agent";
     public override IReadOnlyList<string> EnabledTools => [];
     public override IReadOnlyList<string> SystemPrompt => ["You are a custom agent."];
-    protected override string GetAgentMarkdown() => "# Custom Agent";
+    protected override string GetAgentMarkdown(string? sessionPath = null) => "# Custom Agent";
 }
 
 public class AgentArchitectureGuardTests

--- a/tests/02_abstractions/bashGPT.Agents.Tests/AgentRegistryTests.cs
+++ b/tests/02_abstractions/bashGPT.Agents.Tests/AgentRegistryTests.cs
@@ -8,7 +8,7 @@ file sealed class FakeAgent(string id, string name) : AgentBase
     public override string Name => name;
     public override IReadOnlyList<string> EnabledTools => [];
     public override IReadOnlyList<string> SystemPrompt => ["test"];
-    protected override string GetAgentMarkdown() => $"# {name}";
+    protected override string GetAgentMarkdown(string? sessionPath = null) => $"# {name}";
 }
 
 public class AgentRegistryTests

--- a/tests/02_abstractions/bashGPT.Agents.Tests/AgentStoreTests.cs
+++ b/tests/02_abstractions/bashGPT.Agents.Tests/AgentStoreTests.cs
@@ -8,7 +8,7 @@ file sealed class ConcreteAgent : AgentBase
     public override string Name => "Test-Agent";
     public override IReadOnlyList<string> EnabledTools => ["tool_a", "tool_b"];
     public override IReadOnlyList<string> SystemPrompt => ["Du bist ein Test."];
-    protected override string GetAgentMarkdown() => "# Test-Agent\n\nInfo.";
+    protected override string GetAgentMarkdown(string? sessionPath = null) => "# Test-Agent\n\nInfo.";
 }
 
 public class AgentBaseTests

--- a/tests/06_app/bashGPT.Server.Tests/Server/ServerApplicationTests.cs
+++ b/tests/06_app/bashGPT.Server.Tests/Server/ServerApplicationTests.cs
@@ -93,6 +93,6 @@ public sealed class ServerApplicationTests
         public override string Name => id;
         public override IReadOnlyList<string> EnabledTools => [];
         public override IReadOnlyList<string> SystemPrompt => [];
-        protected override string GetAgentMarkdown() => string.Empty;
+        protected override string GetAgentMarkdown(string? sessionPath = null) => string.Empty;
     }
 }

--- a/tests/06_app/bashGPT.Server.Tests/Server/ToolDefinitionMapperTests.cs
+++ b/tests/06_app/bashGPT.Server.Tests/Server/ToolDefinitionMapperTests.cs
@@ -189,5 +189,5 @@ internal sealed class StubAgent(IReadOnlyList<ITool> ownedTools) : AgentBase
     public override string Name => "Stub Agent";
     public override IReadOnlyList<string> SystemPrompt => ["You are a stub."];
     public override IReadOnlyList<ITool> GetOwnedTools() => ownedTools;
-    protected override string GetAgentMarkdown() => "# Stub";
+    protected override string GetAgentMarkdown(string? sessionPath = null) => "# Stub";
 }


### PR DESCRIPTION
Closes #242

## Summary

- `AgentBase.GetAgentMarkdown` und `GetInfoPanelMarkdown` um optionalen `sessionPath`-Parameter erweitert — analog zu `GetSystemPrompt`
- `DevAgent.GetAgentMarkdown` nutzt `sessionPath` aktiv: geladene Kontextdateien werden im Info-Panel angezeigt
- `AgentsController` nimmt `sessionId` als Query-Parameter entgegen und löst ihn per `ServerSessionService.GetSessionPath()` zum Dateipfad auf
- Frontend übergibt die aktive `sessionId` beim Abrufen des Info-Panels

## Akzeptanzkriterien

- [x] `GetAgentMarkdown(string? sessionPath = null)` ist abstrakt mit optionalem Parameter
- [x] `GetInfoPanelMarkdown` reicht `sessionPath` an `GetAgentMarkdown` weiter
- [x] Alle bestehenden Agent-Implementierungen kompilieren fehlerfrei
- [x] Bestehende Tests passen weiterhin durch