### PR TITLE
feat: add WorkingDirectory to AgentBase for tool execution

### DIFF
--- a/src/02_abstractions/bashGPT.Agents/AgentBase.cs
+++ b/src/02_abstractions/bashGPT.Agents/AgentBase.cs
@@ -87,9 +87,16 @@ public abstract class AgentBase
     {
         var tool = GetOwnedTools().FirstOrDefault(t => t.Definition.Name == toolName);
         if (tool is null) return null;
-        var result = await tool.ExecuteAsync(new ToolCall(toolName, argumentsJson, sessionPath), ct);
+        var result = await tool.ExecuteAsync(new ToolCall(toolName, argumentsJson, sessionPath, WorkingDirectory), ct);
         return result.Content;
     }
+
+    /// <summary>
+    /// Optional working directory for all tool calls of this agent.
+    /// When <c>null</c> the process CWD is used as fallback.
+    /// Explicit per-call paths provided by the LLM always take precedence.
+    /// </summary>
+    public virtual string? WorkingDirectory => null;
 
     /// <summary>
     /// Optional LLM configuration for this agent (model, temperature, top-p, etc.).

--- a/src/02_abstractions/bashGPT.Tools/Abstractions/ToolCall.cs
+++ b/src/02_abstractions/bashGPT.Tools/Abstractions/ToolCall.cs
@@ -6,7 +6,10 @@ namespace bashGPT.Tools.Abstractions;
 /// <param name="Name">Registered tool name.</param>
 /// <param name="ArgumentsJson">Raw JSON arguments provided by the model.</param>
 /// <param name="SessionPath">Optional session-scoped path provided by the server runtime.</param>
+/// <param name="WorkingDirectory">Optional working directory for the tool. When set, tools use this
+/// as the base directory instead of the process CWD. Explicit per-call paths always take precedence.</param>
 public sealed record ToolCall(
     string Name,
     string ArgumentsJson,
-    string? SessionPath = null);
+    string? SessionPath = null,
+    string? WorkingDirectory = null);

--- a/src/03_tools/bashGPT.Tools.Build/BuildRunTool.cs
+++ b/src/03_tools/bashGPT.Tools.Build/BuildRunTool.cs
@@ -67,6 +67,9 @@ public sealed class BuildRunTool : ITool
             return new ToolResult(Success: false, Content: $"Invalid arguments: {ex.Message}");
         }
 
+        if (call.WorkingDirectory is not null)
+            input = input with { Cwd = input.Cwd ?? call.WorkingDirectory };
+
         if (!_runners.ContainsKey(input.Runner))
             return new ToolResult(Success: false, Content: $"Unknown runner '{input.Runner}'. Supported: {string.Join(", ", _runners.Keys)}");
 

--- a/src/03_tools/bashGPT.Tools.Filesystem/FilesystemReadTool.cs
+++ b/src/03_tools/bashGPT.Tools.Filesystem/FilesystemReadTool.cs
@@ -41,7 +41,7 @@ public sealed class FilesystemReadTool : ITool
             return new ToolResult(Success: false, Content: $"Invalid arguments [invalid_json]: {ex.Message}");
         }
 
-        var absolute = Path.GetFullPath(path);
+        var absolute = Path.GetFullPath(path, call.WorkingDirectory ?? Directory.GetCurrentDirectory());
 
         if (!_policy.AllowRead(absolute))
             return new ToolResult(Success: false, Content: $"Read blocked by policy: {absolute}");

--- a/src/03_tools/bashGPT.Tools.Filesystem/FilesystemSearchTool.cs
+++ b/src/03_tools/bashGPT.Tools.Filesystem/FilesystemSearchTool.cs
@@ -36,7 +36,7 @@ public sealed class FilesystemSearchTool : ITool
         int maxMatches;
         try
         {
-            (pattern, searchPath, glob, ignoreCase, maxMatches) = ParseInput(call.ArgumentsJson);
+            (pattern, searchPath, glob, ignoreCase, maxMatches) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (ArgumentException ex)
         {
@@ -126,7 +126,7 @@ public sealed class FilesystemSearchTool : ITool
         return results;
     }
 
-    private static (string Pattern, string Path, string Glob, bool IgnoreCase, int MaxMatches) ParseInput(string json)
+    private static (string Pattern, string Path, string Glob, bool IgnoreCase, int MaxMatches) ParseInput(string json, string? workingDirectory = null)
     {
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
@@ -139,9 +139,9 @@ public sealed class FilesystemSearchTool : ITool
         if (string.IsNullOrWhiteSpace(pattern))
             throw new ArgumentException("invalid_value: 'pattern' must not be empty.");
 
-        var path = ReadOptionalString(root, "path") ?? Directory.GetCurrentDirectory();
+        var path = ReadOptionalString(root, "path") ?? workingDirectory ?? Directory.GetCurrentDirectory();
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = workingDirectory ?? Directory.GetCurrentDirectory();
 
         var glob = ReadOptionalString(root, "glob") ?? string.Empty;
         bool ignoreCase = ReadOptionalBool(root, "ignoreCase") ?? false;

--- a/src/03_tools/bashGPT.Tools.Filesystem/FilesystemWriteTool.cs
+++ b/src/03_tools/bashGPT.Tools.Filesystem/FilesystemWriteTool.cs
@@ -40,7 +40,7 @@ public sealed class FilesystemWriteTool : ITool
             return new ToolResult(Success: false, Content: $"Invalid arguments [invalid_json]: {ex.Message}");
         }
 
-        var absolute = Path.GetFullPath(path);
+        var absolute = Path.GetFullPath(path, call.WorkingDirectory ?? Directory.GetCurrentDirectory());
 
         if (!_policy.AllowWrite(absolute))
             return new ToolResult(Success: false, Content: $"Write blocked by policy: {absolute}");

--- a/src/03_tools/bashGPT.Tools.Git/GitAddTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitAddTool.cs
@@ -26,7 +26,7 @@ public sealed class GitAddTool : ITool
         string repoPath, files;
         try
         {
-            (repoPath, files) = ParseInput(call.ArgumentsJson);
+            (repoPath, files) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (Exception ex)
         {
@@ -44,8 +44,9 @@ public sealed class GitAddTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(new { staged = files }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static (string Path, string Files) ParseInput(string json)
+    private static (string Path, string Files) ParseInput(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
@@ -60,13 +61,13 @@ public sealed class GitAddTool : ITool
         var path = root.TryGetProperty("path", out var p)
             ? p.ValueKind switch
             {
-                JsonValueKind.String => p.GetString() ?? Directory.GetCurrentDirectory(),
-                JsonValueKind.Null => Directory.GetCurrentDirectory(),
+                JsonValueKind.String => p.GetString() ?? cwd,
+                JsonValueKind.Null => cwd,
                 _ => throw new ArgumentException("invalid_type: 'path' must be a string."),
             }
-            : Directory.GetCurrentDirectory();
+            : cwd;
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = cwd;
 
         return (path, files);
     }

--- a/src/03_tools/bashGPT.Tools.Git/GitBranchTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitBranchTool.cs
@@ -27,7 +27,7 @@ public sealed class GitBranchTool : ITool
         bool remotes;
         try
         {
-            (repoPath, remotes) = ParseInput(call.ArgumentsJson);
+            (repoPath, remotes) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (Exception ex)
         {
@@ -54,21 +54,22 @@ public sealed class GitBranchTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(result, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static (string Path, bool Remotes) ParseInput(string json)
+    private static (string Path, bool Remotes) ParseInput(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
         var path = root.TryGetProperty("path", out var p)
             ? p.ValueKind switch
             {
-                JsonValueKind.String => p.GetString() ?? Directory.GetCurrentDirectory(),
-                JsonValueKind.Null => Directory.GetCurrentDirectory(),
+                JsonValueKind.String => p.GetString() ?? cwd,
+                JsonValueKind.Null => cwd,
                 _ => throw new ArgumentException("invalid_type: 'path' must be a string."),
             }
-            : Directory.GetCurrentDirectory();
+            : cwd;
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = cwd;
 
         bool remotes = root.TryGetProperty("remotes", out var r)
             ? r.ValueKind switch

--- a/src/03_tools/bashGPT.Tools.Git/GitCheckoutTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitCheckoutTool.cs
@@ -28,7 +28,7 @@ public sealed class GitCheckoutTool : ITool
         bool create;
         try
         {
-            (repoPath, branch, create) = ParseInput(call.ArgumentsJson);
+            (repoPath, branch, create) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (Exception ex)
         {
@@ -48,8 +48,9 @@ public sealed class GitCheckoutTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(result, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static (string Path, string Branch, bool Create) ParseInput(string json)
+    private static (string Path, string Branch, bool Create) ParseInput(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
@@ -74,13 +75,13 @@ public sealed class GitCheckoutTool : ITool
         var path = root.TryGetProperty("path", out var p)
             ? p.ValueKind switch
             {
-                JsonValueKind.String => p.GetString() ?? Directory.GetCurrentDirectory(),
-                JsonValueKind.Null => Directory.GetCurrentDirectory(),
+                JsonValueKind.String => p.GetString() ?? cwd,
+                JsonValueKind.Null => cwd,
                 _ => throw new ArgumentException("invalid_type: 'path' must be a string."),
             }
-            : Directory.GetCurrentDirectory();
+            : cwd;
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = cwd;
 
         return (path, branch, create);
     }

--- a/src/03_tools/bashGPT.Tools.Git/GitCommitTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitCommitTool.cs
@@ -26,7 +26,7 @@ public sealed class GitCommitTool : ITool
         string repoPath, message;
         try
         {
-            (repoPath, message) = ParseInput(call.ArgumentsJson);
+            (repoPath, message) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (Exception ex)
         {
@@ -47,8 +47,9 @@ public sealed class GitCommitTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(result, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static (string Path, string Message) ParseInput(string json)
+    private static (string Path, string Message) ParseInput(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
@@ -63,13 +64,13 @@ public sealed class GitCommitTool : ITool
         var path = root.TryGetProperty("path", out var p)
             ? p.ValueKind switch
             {
-                JsonValueKind.String => p.GetString() ?? Directory.GetCurrentDirectory(),
-                JsonValueKind.Null => Directory.GetCurrentDirectory(),
+                JsonValueKind.String => p.GetString() ?? cwd,
+                JsonValueKind.Null => cwd,
                 _ => throw new ArgumentException("invalid_type: 'path' must be a string."),
             }
-            : Directory.GetCurrentDirectory();
+            : cwd;
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = cwd;
 
         return (path, message);
     }

--- a/src/03_tools/bashGPT.Tools.Git/GitDiffTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitDiffTool.cs
@@ -31,7 +31,7 @@ public sealed class GitDiffTool : ITool
         string files;
         try
         {
-            (repoPath, staged, files) = ParseInput(call.ArgumentsJson);
+            (repoPath, staged, files) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (Exception ex)
         {
@@ -55,21 +55,22 @@ public sealed class GitDiffTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(result, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static (string Path, bool Staged, string Files) ParseInput(string json)
+    private static (string Path, bool Staged, string Files) ParseInput(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
         var path = root.TryGetProperty("path", out var p)
             ? p.ValueKind switch
             {
-                JsonValueKind.String => p.GetString() ?? Directory.GetCurrentDirectory(),
-                JsonValueKind.Null => Directory.GetCurrentDirectory(),
+                JsonValueKind.String => p.GetString() ?? cwd,
+                JsonValueKind.Null => cwd,
                 _ => throw new ArgumentException("invalid_type: 'path' must be a string."),
             }
-            : Directory.GetCurrentDirectory();
+            : cwd;
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = cwd;
 
         bool staged = root.TryGetProperty("staged", out var s)
             ? s.ValueKind switch

--- a/src/03_tools/bashGPT.Tools.Git/GitLogTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitLogTool.cs
@@ -28,7 +28,7 @@ public sealed class GitLogTool : ITool
         int limit;
         try
         {
-            (repoPath, limit, branch) = ParseInput(call.ArgumentsJson);
+            (repoPath, limit, branch) = ParseInput(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (Exception ex)
         {
@@ -63,21 +63,22 @@ public sealed class GitLogTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(result, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static (string Path, int Limit, string Branch) ParseInput(string json)
+    private static (string Path, int Limit, string Branch) ParseInput(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
         var path = root.TryGetProperty("path", out var p)
             ? p.ValueKind switch
             {
-                JsonValueKind.String => p.GetString() ?? Directory.GetCurrentDirectory(),
-                JsonValueKind.Null => Directory.GetCurrentDirectory(),
+                JsonValueKind.String => p.GetString() ?? cwd,
+                JsonValueKind.Null => cwd,
                 _ => throw new ArgumentException("invalid_type: 'path' must be a string."),
             }
-            : Directory.GetCurrentDirectory();
+            : cwd;
         if (string.IsNullOrWhiteSpace(path))
-            path = Directory.GetCurrentDirectory();
+            path = cwd;
 
         int limit = root.TryGetProperty("limit", out var l)
             ? l.ValueKind switch

--- a/src/03_tools/bashGPT.Tools.Git/GitStatusTool.cs
+++ b/src/03_tools/bashGPT.Tools.Git/GitStatusTool.cs
@@ -25,7 +25,7 @@ public sealed class GitStatusTool : ITool
         string repoPath;
         try
         {
-            repoPath = ParsePath(call.ArgumentsJson);
+            repoPath = ParsePath(call.ArgumentsJson, call.WorkingDirectory);
         }
         catch (ArgumentException ex)
         {
@@ -72,18 +72,19 @@ public sealed class GitStatusTool : ITool
         return new ToolResult(Success: true, Content: JsonSerializer.Serialize(result, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
     }
 
-    private static string ParsePath(string json)
+    private static string ParsePath(string json, string? workingDirectory = null)
     {
+        var cwd = workingDirectory ?? Directory.GetCurrentDirectory();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
         if (!root.TryGetProperty("path", out var p))
-            return Directory.GetCurrentDirectory();
+            return cwd;
         if (p.ValueKind is JsonValueKind.Null)
-            return Directory.GetCurrentDirectory();
+            return cwd;
         if (p.ValueKind is not JsonValueKind.String)
             throw new ArgumentException("invalid_type: 'path' must be a string.");
 
         var path = p.GetString();
-        return string.IsNullOrWhiteSpace(path) ? Directory.GetCurrentDirectory() : path;
+        return string.IsNullOrWhiteSpace(path) ? cwd : path;
     }
 }

--- a/src/03_tools/bashGPT.Tools.Shell/ShellExecBase.cs
+++ b/src/03_tools/bashGPT.Tools.Shell/ShellExecBase.cs
@@ -48,6 +48,9 @@ public abstract class ShellExecBase : ITool
             return new ToolResult(Success: false, Content: $"Invalid arguments: {ex.Message}");
         }
 
+        if (call.WorkingDirectory is not null)
+            input = input with { Cwd = input.Cwd ?? call.WorkingDirectory };
+
         if (!_policy.Allow(input))
             return new ToolResult(Success: false, Content: "Command blocked by policy.");
 

--- a/src/03_tools/bashGPT.Tools.Testing/TestRunTool.cs
+++ b/src/03_tools/bashGPT.Tools.Testing/TestRunTool.cs
@@ -75,6 +75,9 @@ public sealed class TestRunTool : ITool
             return new ToolResult(Success: false, Content: $"Invalid arguments: {ex.Message}");
         }
 
+        if (call.WorkingDirectory is not null)
+            input = input with { Cwd = input.Cwd ?? call.WorkingDirectory };
+
         if (!_runners.ContainsKey(input.Runner))
             return new ToolResult(Success: false, Content: $"Unknown runner '{input.Runner}'. Supported: {string.Join(", ", _runners.Keys)}");
 

--- a/src/04_agents/bashGPT.Agents.Dev/DevAgent.cs
+++ b/src/04_agents/bashGPT.Agents.Dev/DevAgent.cs
@@ -10,9 +10,17 @@ namespace bashGPT.Agents.Dev;
 /// </summary>
 public sealed class DevAgent : AgentBase
 {
+    private readonly string _workingDirectory = Directory.GetCurrentDirectory();
+
     public override string Id => "dev";
 
     public override string Name => "Dev-Agent";
+
+    /// <summary>
+    /// Working directory captured at agent startup. Ensures all tool calls operate in the
+    /// same directory regardless of later process CWD changes.
+    /// </summary>
+    public override string? WorkingDirectory => _workingDirectory;
 
     // Context tools are owned directly — no registry needed.
     public override IReadOnlyList<ITool> GetOwnedTools() =>
@@ -77,9 +85,9 @@ public sealed class DevAgent : AgentBase
     /// Builds project context at runtime: git info plus all tracked files.
     /// Ignored files (.gitignore) are omitted. Rebuilt fresh for every chat request.
     /// </summary>
-    private static string BuildProjectContext()
+    private string BuildProjectContext()
     {
-        var cwd = Directory.GetCurrentDirectory();
+        var cwd = _workingDirectory;
         var sb  = new StringBuilder("# Project Context\n\n");
 
         sb.AppendLine($"**Directory:** `{cwd}`\n");

--- a/src/06_app/bashGPT.Server/Services/ServerToolCallOrchestrator.cs
+++ b/src/06_app/bashGPT.Server/Services/ServerToolCallOrchestrator.cs
@@ -84,7 +84,7 @@ internal static class ServerToolCallOrchestrator
             try
             {
                 var result = await tool.ExecuteAsync(
-                    new bashGPT.Tools.Abstractions.ToolCall(call.Name, call.ArgumentsJson ?? "{}", sessionPath), ct);
+                    new bashGPT.Tools.Abstractions.ToolCall(call.Name, call.ArgumentsJson ?? "{}", sessionPath, agent?.WorkingDirectory), ct);
 
                 return (
                     result.Content,


### PR DESCRIPTION
Closes #244

## Summary

- `AgentBase.WorkingDirectory` — neue virtuelle Property (default `null`); Agents überschreiben sie, um Tools in das richtige Verzeichnis zu lenken
- `ToolCall` — optionale `WorkingDirectory`-Property ergänzt
- `TryHandleToolCallAsync` — reicht `WorkingDirectory` beim Aufbau des `ToolCall` weiter
- Alle pfadsensitiven Tools (Shell, Filesystem, Git, Build, Test) — verwenden `WorkingDirectory` als Basis, Fallback auf Prozess-CWD
- `ServerToolCallOrchestrator` — setzt `WorkingDirectory` des aktiven Agents beim Aufbau des `ToolCall`
- `DevAgent` — erfasst das CWD beim Start einmalig und überschreibt `WorkingDirectory` sowie `BuildProjectContext`

## Akzeptanzkriterien

- [x] `AgentBase.WorkingDirectory` ist eine virtuelle, optionale Property (default `null`)
- [x] `ToolCall` trägt ein optionales `WorkingDirectory`
- [x] `TryHandleToolCallAsync` reicht `WorkingDirectory` in den `ToolCall` ein
- [x] Alle pfadsensitiven Tools verwenden `WorkingDirectory` als Basis (Fallback: Prozess-CWD)
- [x] `ServerToolCallOrchestrator` setzt `WorkingDirectory` beim Aufbau des `ToolCall`
- [x] Bestehende Tests kompilieren und laufen weiterhin grün